### PR TITLE
fix(stripe-webhook): call blind-sponsorship match directly

### DIFF
--- a/src/app/api/admin/blind-sponsorships/match/route.ts
+++ b/src/app/api/admin/blind-sponsorships/match/route.ts
@@ -1,22 +1,22 @@
 import { NextResponse } from "next/server"
 import { createClient } from "@/utils/supabase/server"
 import { requireSuperAdmin } from "@/utils/auth/requireSuperAdmin"
-import { sendBlindSponsorshipMatchedEmail } from "@/utils/email"
-import { WAITING_STATUSES } from "@/config/beneficiaryStatuses"
+import {
+  autoMatchBlindSponsorships,
+  matchBeneficiaryToOldestBlindSponsorship,
+  matchByStripeSubscriptionId,
+  matchSpecificSubscription,
+  type MatchResult,
+} from "@/utils/blindSponsorships/match"
+
 export const runtime = "nodejs"
 
-type SupabaseClient = Awaited<ReturnType<typeof createClient>>
-
 /**
- * API endpoint to match blind sponsorships with beneficiaries
- * 
- * This can be called:
- * 1. Manually by admin
- * 2. Automatically when a new beneficiary is created
- * 3. Via a cron job/scheduled task
- * 
+ * API endpoint to match blind sponsorships with beneficiaries.
+ *
  * Query params:
- * - subscriptionId: Match a specific blind sponsorship
+ * - subscriptionId: Match a specific blind sponsorship (internal ID)
+ * - stripeSubscriptionId: Match a specific blind sponsorship (Stripe ID)
  * - beneficiaryId: Match to a specific beneficiary
  * - auto: Automatically match oldest blind sponsorship with best available beneficiary
  */
@@ -32,47 +32,33 @@ export async function POST(req: Request) {
     const beneficiaryId = searchParams.get("beneficiaryId")
     const auto = searchParams.get("auto") === "true"
 
-    // If Stripe subscription ID provided, look up database ID first
     if (stripeSubscriptionId) {
-      const { data: subscription } = await supabase
-        .from("subscriptions")
-        .select("id")
-        .eq("stripe_subscription_id", stripeSubscriptionId)
-        .single()
-      
-      if (subscription) {
-        return await matchSpecificSubscription(
+      return toResponse(
+        await matchByStripeSubscriptionId(
           supabase,
-          subscription.id,
+          stripeSubscriptionId,
           beneficiaryId || undefined,
-        )
-      }
-      
-      return NextResponse.json(
-        { error: "Subscription not found" },
-        { status: 404 },
+        ),
       )
     }
 
-    // If specific subscription ID provided, match that one
     if (subscriptionId) {
-      return await matchSpecificSubscription(
-        supabase,
-        subscriptionId,
-        beneficiaryId || undefined,
+      return toResponse(
+        await matchSpecificSubscription(
+          supabase,
+          subscriptionId,
+          beneficiaryId || undefined,
+        ),
       )
     }
 
-    // If auto mode, match oldest blind sponsorship with best available beneficiary
     if (auto) {
-      return await autoMatchBlindSponsorships(supabase)
+      return toResponse(await autoMatchBlindSponsorships(supabase))
     }
 
-    // If beneficiary ID provided but no subscription, find oldest blind sponsorship
     if (beneficiaryId) {
-      return await matchBeneficiaryToOldestBlindSponsorship(
-        supabase,
-        beneficiaryId,
+      return toResponse(
+        await matchBeneficiaryToOldestBlindSponsorship(supabase, beneficiaryId),
       )
     }
 
@@ -89,318 +75,16 @@ export async function POST(req: Request) {
   }
 }
 
-async function matchSpecificSubscription(
-  supabase: SupabaseClient,
-  subscriptionId: string,
-  beneficiaryId?: string,
-) {
-  // Get the blind sponsorship
-  const { data: subscription, error: subError } = await supabase
-    .from("subscriptions")
-    .select("*, users(email, first_name, last_name)")
-    .eq("id", subscriptionId)
-    .is("beneficiary_id", null)
-    .eq("status", "complete")
-    .single()
-
-  if (subError || !subscription) {
-    return NextResponse.json(
-      { error: "Blind sponsorship not found or already matched" },
-      { status: 404 },
-    )
-  }
-
-  // If beneficiary ID provided, use that; otherwise find best match
-  const targetBeneficiaryId = beneficiaryId || await findBestBeneficiaryMatch(supabase)
-
-  if (!targetBeneficiaryId) {
-    return NextResponse.json(
-      { error: "No available beneficiary found for matching" },
-      { status: 404 },
-    )
-  }
-
-  // Update subscription with beneficiary
-  const { data: updatedSubscription, error: updateError } = await supabase
-    .from("subscriptions")
-    .update({ beneficiary_id: targetBeneficiaryId })
-    .eq("id", subscriptionId)
-    .select()
-    .single()
-
-  if (updateError) {
-    console.error("Error updating subscription:", {
-      subscriptionId,
-      targetBeneficiaryId,
-      error: updateError,
-      message: updateError.message,
-      details: updateError.details,
-      hint: updateError.hint,
-      code: updateError.code
+function toResponse(result: MatchResult): NextResponse {
+  if (result.ok) {
+    return NextResponse.json({
+      success: true,
+      subscription: result.subscription,
+      beneficiary: result.beneficiary,
     })
-    return NextResponse.json(
-      { 
-        error: "Failed to update subscription",
-        details: updateError.message,
-        code: updateError.code
-      },
-      { status: 500 },
-    )
   }
-
-  // Get beneficiary details for email
-  const { data: beneficiary } = await supabase
-    .from("beneficiaries")
-    .select("name, username")
-    .eq("id", targetBeneficiaryId)
-    .single()
-
-  if (!beneficiary) {
-    return NextResponse.json(
-      { error: "Beneficiary not found" },
-      { status: 404 },
-    )
-  }
-
-  // Send notification email
-  const user = subscription.users as { email?: string; first_name?: string; last_name?: string } | null
-  if (user?.email) {
-    try {
-      await sendBlindSponsorshipMatchedEmail(
-        user.email,
-        beneficiary.name || "a child",
-        subscription.amount || 0,
-        subscription.interval || "month",
-        user.first_name || user.last_name ? `${user.first_name || ""} ${user.last_name || ""}`.trim() : null,
-        beneficiary.username,
-        targetBeneficiaryId,
-      )
-    } catch (emailError) {
-      console.error("Error sending match notification email:", emailError)
-      // Don't fail the request if email fails
-    }
-  }
-
-  return NextResponse.json({
-    success: true,
-    subscription: updatedSubscription,
-    beneficiary: beneficiary,
-  })
-}
-
-/**
- * Automatically match the oldest blind sponsorship with the best available beneficiary
- */
-async function autoMatchBlindSponsorships(
-  supabase: SupabaseClient,
-) {
-  // Get oldest blind sponsorship
-  const { data: blindSponsorships, error: subError } = await supabase
-    .from("subscriptions")
-    .select("*, users(email, first_name, last_name)")
-    .is("beneficiary_id", null)
-    .eq("status", "complete")
-    .order("created_at", { ascending: true })
-    .limit(1)
-
-  if (subError || !blindSponsorships || blindSponsorships.length === 0) {
-    return NextResponse.json(
-      { error: "No blind sponsorships found to match" },
-      { status: 404 },
-    )
-  }
-
-  const subscription = blindSponsorships[0]
-
-  // Find best beneficiary match
-  const beneficiaryId = await findBestBeneficiaryMatch(
-    supabase
-  )
-
-  if (!beneficiaryId) {
-    return NextResponse.json(
-      { error: "No available beneficiary found for matching" },
-      { status: 404 },
-    )
-  }
-
-  // Update subscription
-  const { data: updatedSubscription, error: updateError } = await supabase
-    .from("subscriptions")
-    .update({ beneficiary_id: beneficiaryId })
-    .eq("id", subscription.id)
-    .select()
-    .single()
-
-  if (updateError) {
-    console.error("Error updating subscription:", updateError)
-    return NextResponse.json(
-      { error: "Failed to update subscription" },
-      { status: 500 },
-    )
-  }
-
-  // Get beneficiary details
-  const { data: beneficiary } = await supabase
-    .from("beneficiaries")
-    .select("name, username")
-    .eq("id", beneficiaryId)
-    .single()
-
-  if (!beneficiary) {
-    return NextResponse.json(
-      { error: "Beneficiary not found" },
-      { status: 404 },
-    )
-  }
-
-  // Send notification email
-  const user = subscription.users as { email?: string; first_name?: string; last_name?: string } | null
-  if (user?.email) {
-    try {
-      await sendBlindSponsorshipMatchedEmail(
-        user.email,
-        beneficiary.name || "a child",
-        subscription.amount || 0,
-        subscription.interval || "month",
-        user.first_name || user.last_name ? `${user.first_name || ""} ${user.last_name || ""}`.trim() : null,
-        beneficiary.username,
-        beneficiaryId,
-      )
-    } catch (emailError) {
-      console.error("Error sending match notification email:", emailError)
-    }
-  }
-
-  return NextResponse.json({
-    success: true,
-    subscription: updatedSubscription,
-    beneficiary: beneficiary,
-  })
-}
-
-/**
- * Match a specific beneficiary to the oldest blind sponsorship
- */
-async function matchBeneficiaryToOldestBlindSponsorship(
-  supabase: SupabaseClient,
-  beneficiaryId: string,
-) {
-  // Verify beneficiary exists and is available
-  const { data: beneficiary, error: benError } = await supabase
-    .from("beneficiaries")
-    .select("id, name, username, status, budget_goal, budget_raised, beneficiary_type")
-    .eq("id", beneficiaryId)
-    .or(`status.in.(${WAITING_STATUSES.map(s => `"${s}"`).join(",")}),and(budget_goal.eq.-1,status.not.in.(Draft,Archived))`)
-    .single()
-
-  if (benError || !beneficiary) {
-    return NextResponse.json(
-      { error: "Beneficiary not found or not available for sponsorship" },
-      { status: 404 },
-    )
-  }
-
-  // Get oldest blind sponsorship
-  const { data: blindSponsorships, error: subError } = await supabase
-    .from("subscriptions")
-    .select("*, users(email, first_name, last_name)")
-    .is("beneficiary_id", null)
-    .eq("status", "complete")
-    .order("created_at", { ascending: true })
-    .limit(1)
-
-  if (subError || !blindSponsorships || blindSponsorships.length === 0) {
-    return NextResponse.json(
-      { error: "No blind sponsorships found to match" },
-      { status: 404 },
-    )
-  }
-
-  const subscription = blindSponsorships[0]
-
-  // Update subscription
-  const { data: updatedSubscription, error: updateError } = await supabase
-    .from("subscriptions")
-    .update({ beneficiary_id: beneficiaryId })
-    .eq("id", subscription.id)
-    .select()
-    .single()
-
-  if (updateError) {
-    console.error("Error updating subscription:", updateError)
-    return NextResponse.json(
-      { error: "Failed to update subscription" },
-      { status: 500 },
-    )
-  }
-
-  // Send notification email
-  const user = subscription.users as { email?: string; first_name?: string; last_name?: string } | null
-  if (user?.email) {
-    try {
-      await sendBlindSponsorshipMatchedEmail(
-        user.email,
-        beneficiary.name || "a child",
-        subscription.amount || 0,
-        subscription.interval || "month",
-        user.first_name || user.last_name ? `${user.first_name || ""} ${user.last_name || ""}`.trim() : null,
-        beneficiary.username,
-        beneficiaryId,
-      )
-    } catch (emailError) {
-      console.error("Error sending match notification email:", emailError)
-    }
-  }
-
-  return NextResponse.json({
-    success: true,
-    subscription: updatedSubscription,
-    beneficiary: beneficiary,
-  })
-}
-
-/**
- * Find the best beneficiary match for a blind sponsorship
- * Priority:
- * 1. Status: "New" (no active subscriptions yet)
- * 2. Sort by: sort_weight DESC (higher priority), then created_at ASC (oldest first)
- * 3. Not already fulfilled
- * 4. Does NOT have any active subscriptions (due to unique constraint)
- */
-async function findBestBeneficiaryMatch(
-  supabase: SupabaseClient
-): Promise<string | null> {
-  // Get beneficiaries with NO active subscriptions
-  const { data: beneficiaries, error } = await supabase
-    .from("beneficiaries")
-    .select("id, name, status, budget_goal, budget_raised, sort_weight, beneficiary_type")
-    .or("beneficiary_type.eq.CHILD,beneficiary_type.is.null")
-    .eq("status", "New") // Only "New" beneficiaries have no active subscriptions
-    .is("goal_fulfilled_at", null)
-    .eq("active_subscriptions", 0) // Explicitly check for 0 active subscriptions
-    .order("sort_weight", { ascending: false }) // Higher weight = higher priority
-    .order("created_at", { ascending: true }) // Oldest first
-    .limit(10) // Get top candidates
-
-  if (error) {
-    console.error("Error finding beneficiary match:", error)
-    return null
-  }
-
-  if (!beneficiaries || beneficiaries.length === 0) {
-    return null
-  }
-
-  // Find the first beneficiary that still needs funding.
-  // Note: the query above filters to CHILD/null types only, so open sponsorship
-  // types (SPECIAL_NEEDS) are intentionally excluded from blind matching.
-  for (const beneficiary of beneficiaries) {
-    const remaining = (beneficiary.budget_goal || 0) - (beneficiary.budget_raised || 0)
-    if (remaining > 0) {
-      return beneficiary.id
-    }
-  }
-
-  return null
+  const body: Record<string, unknown> = { error: result.error }
+  if (result.details) body.details = result.details
+  if (result.code) body.code = result.code
+  return NextResponse.json(body, { status: result.status })
 }

--- a/src/app/api/webhooks/stripe/route.ts
+++ b/src/app/api/webhooks/stripe/route.ts
@@ -10,6 +10,7 @@ import {
   sendManagerSponsorshipNotificationEmail,
 } from "@/utils/email"
 import { notifySponsorshipReceived } from "@/services/telegram"
+import { matchByStripeSubscriptionId } from "@/utils/blindSponsorships/match"
 
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY! as string)
 
@@ -593,25 +594,16 @@ export async function POST(req: Request) {
         // Step 6: Auto-match blind sponsorships
         if (isBlindSponsorship && session.subscription) {
           try {
-            // Call the matching endpoint to automatically assign an available beneficiary
-            const matchResponse = await fetch(
-              `${process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000'}/api/admin/blind-sponsorships/match?stripeSubscriptionId=${session.subscription}`,
-              {
-                method: 'POST',
-                headers: {
-                  'Content-Type': 'application/json',
-                },
-              }
+            const stripeSubscriptionId = session.subscription as string
+            const matchResult = await matchByStripeSubscriptionId(
+              supabase,
+              stripeSubscriptionId,
             )
-            
-            if (matchResponse.ok) {
-              await matchResponse.json()
-            } else {
-              const errorData = await matchResponse.json()
+            if (!matchResult.ok) {
               console.error("Blind sponsorship auto-match failed:", {
-                subscriptionId: session.subscription,
-                status: matchResponse.status,
-                error: errorData.error,
+                subscriptionId: stripeSubscriptionId,
+                status: matchResult.status,
+                error: matchResult.error,
               })
               // Don't fail the webhook - matching can be done manually later
             }

--- a/src/utils/blindSponsorships/match.ts
+++ b/src/utils/blindSponsorships/match.ts
@@ -1,0 +1,274 @@
+import type { SupabaseClient } from "@supabase/supabase-js"
+import { sendBlindSponsorshipMatchedEmail } from "@/utils/email"
+import { WAITING_STATUSES } from "@/config/beneficiaryStatuses"
+
+type SubscriptionRow = {
+  id: string
+  amount: number | null
+  interval: string | null
+  users: { email?: string; first_name?: string; last_name?: string } | null
+}
+
+type BeneficiaryRow = {
+  id: string
+  name: string | null
+  username: string | null
+}
+
+export type MatchSuccess = {
+  ok: true
+  subscription: Record<string, unknown>
+  beneficiary: BeneficiaryRow
+}
+
+export type MatchFailure = {
+  ok: false
+  error: string
+  status: number
+  details?: string
+  code?: string
+}
+
+export type MatchResult = MatchSuccess | MatchFailure
+
+/**
+ * Match a specific blind sponsorship (by internal subscription ID) to a beneficiary.
+ * If beneficiaryId is omitted, picks the best available beneficiary.
+ */
+export async function matchSpecificSubscription(
+  supabase: SupabaseClient,
+  subscriptionId: string,
+  beneficiaryId?: string,
+): Promise<MatchResult> {
+  const { data: subscription, error: subError } = await supabase
+    .from("subscriptions")
+    .select("*, users(email, first_name, last_name)")
+    .eq("id", subscriptionId)
+    .is("beneficiary_id", null)
+    .eq("status", "complete")
+    .single<SubscriptionRow & Record<string, unknown>>()
+
+  if (subError || !subscription) {
+    return {
+      ok: false,
+      error: "Blind sponsorship not found or already matched",
+      status: 404,
+    }
+  }
+
+  const targetBeneficiaryId =
+    beneficiaryId || (await findBestBeneficiaryMatch(supabase))
+
+  if (!targetBeneficiaryId) {
+    return {
+      ok: false,
+      error: "No available beneficiary found for matching",
+      status: 404,
+    }
+  }
+
+  return finalizeMatch(supabase, subscription, targetBeneficiaryId)
+}
+
+/**
+ * Look up a subscription by Stripe subscription ID, then match it.
+ * This is the entry point used by the Stripe webhook on checkout completion.
+ */
+export async function matchByStripeSubscriptionId(
+  supabase: SupabaseClient,
+  stripeSubscriptionId: string,
+  beneficiaryId?: string,
+): Promise<MatchResult> {
+  const { data: subscription } = await supabase
+    .from("subscriptions")
+    .select("id")
+    .eq("stripe_subscription_id", stripeSubscriptionId)
+    .single<{ id: string }>()
+
+  if (!subscription) {
+    return { ok: false, error: "Subscription not found", status: 404 }
+  }
+
+  return matchSpecificSubscription(supabase, subscription.id, beneficiaryId)
+}
+
+/**
+ * Match the oldest unmatched blind sponsorship to the best available beneficiary.
+ */
+export async function autoMatchBlindSponsorships(
+  supabase: SupabaseClient,
+): Promise<MatchResult> {
+  const subscription = await getOldestBlindSponsorship(supabase)
+  if (!subscription) {
+    return {
+      ok: false,
+      error: "No blind sponsorships found to match",
+      status: 404,
+    }
+  }
+
+  const beneficiaryId = await findBestBeneficiaryMatch(supabase)
+  if (!beneficiaryId) {
+    return {
+      ok: false,
+      error: "No available beneficiary found for matching",
+      status: 404,
+    }
+  }
+
+  return finalizeMatch(supabase, subscription, beneficiaryId)
+}
+
+/**
+ * Match a specific available beneficiary to the oldest unmatched blind sponsorship.
+ */
+export async function matchBeneficiaryToOldestBlindSponsorship(
+  supabase: SupabaseClient,
+  beneficiaryId: string,
+): Promise<MatchResult> {
+  const { data: beneficiary, error: benError } = await supabase
+    .from("beneficiaries")
+    .select("id, name, username, status, budget_goal, budget_raised, beneficiary_type")
+    .eq("id", beneficiaryId)
+    .or(
+      `status.in.(${WAITING_STATUSES.map((s) => `"${s}"`).join(",")}),and(budget_goal.eq.-1,status.not.in.(Draft,Archived))`,
+    )
+    .single()
+
+  if (benError || !beneficiary) {
+    return {
+      ok: false,
+      error: "Beneficiary not found or not available for sponsorship",
+      status: 404,
+    }
+  }
+
+  const subscription = await getOldestBlindSponsorship(supabase)
+  if (!subscription) {
+    return {
+      ok: false,
+      error: "No blind sponsorships found to match",
+      status: 404,
+    }
+  }
+
+  return finalizeMatch(supabase, subscription, beneficiaryId)
+}
+
+async function getOldestBlindSponsorship(
+  supabase: SupabaseClient,
+): Promise<(SubscriptionRow & Record<string, unknown>) | null> {
+  const { data, error } = await supabase
+    .from("subscriptions")
+    .select("*, users(email, first_name, last_name)")
+    .is("beneficiary_id", null)
+    .eq("status", "complete")
+    .order("created_at", { ascending: true })
+    .limit(1)
+
+  if (error || !data || data.length === 0) return null
+  return data[0] as SubscriptionRow & Record<string, unknown>
+}
+
+async function finalizeMatch(
+  supabase: SupabaseClient,
+  subscription: SubscriptionRow & Record<string, unknown>,
+  beneficiaryId: string,
+): Promise<MatchResult> {
+  const { data: updatedSubscription, error: updateError } = await supabase
+    .from("subscriptions")
+    .update({ beneficiary_id: beneficiaryId })
+    .eq("id", subscription.id)
+    .select()
+    .single()
+
+  if (updateError) {
+    console.error("Error updating subscription:", {
+      subscriptionId: subscription.id,
+      beneficiaryId,
+      error: updateError,
+      message: updateError.message,
+      details: updateError.details,
+      hint: updateError.hint,
+      code: updateError.code,
+    })
+    return {
+      ok: false,
+      error: "Failed to update subscription",
+      status: 500,
+      details: updateError.message,
+      code: updateError.code,
+    }
+  }
+
+  const { data: beneficiary } = await supabase
+    .from("beneficiaries")
+    .select("id, name, username")
+    .eq("id", beneficiaryId)
+    .single<BeneficiaryRow>()
+
+  if (!beneficiary) {
+    return { ok: false, error: "Beneficiary not found", status: 404 }
+  }
+
+  const user = subscription.users
+  if (user?.email) {
+    try {
+      const fullName =
+        user.first_name || user.last_name
+          ? `${user.first_name || ""} ${user.last_name || ""}`.trim()
+          : null
+      await sendBlindSponsorshipMatchedEmail(
+        user.email,
+        beneficiary.name || "a child",
+        subscription.amount || 0,
+        subscription.interval || "month",
+        fullName,
+        beneficiary.username,
+        beneficiaryId,
+      )
+    } catch (emailError) {
+      console.error("Error sending match notification email:", emailError)
+    }
+  }
+
+  return {
+    ok: true,
+    subscription: updatedSubscription as Record<string, unknown>,
+    beneficiary,
+  }
+}
+
+/**
+ * Pick the best beneficiary for a blind sponsorship.
+ * Priority: status="New" (no active subs), highest sort_weight, oldest first,
+ * still under-funded. CHILD/null types only — open-sponsorship types are excluded.
+ */
+async function findBestBeneficiaryMatch(
+  supabase: SupabaseClient,
+): Promise<string | null> {
+  const { data: beneficiaries, error } = await supabase
+    .from("beneficiaries")
+    .select("id, name, status, budget_goal, budget_raised, sort_weight, beneficiary_type")
+    .or("beneficiary_type.eq.CHILD,beneficiary_type.is.null")
+    .eq("status", "New")
+    .is("goal_fulfilled_at", null)
+    .eq("active_subscriptions", 0)
+    .order("sort_weight", { ascending: false })
+    .order("created_at", { ascending: true })
+    .limit(10)
+
+  if (error) {
+    console.error("Error finding beneficiary match:", error)
+    return null
+  }
+
+  if (!beneficiaries || beneficiaries.length === 0) return null
+
+  for (const beneficiary of beneficiaries) {
+    const remaining = (beneficiary.budget_goal || 0) - (beneficiary.budget_raised || 0)
+    if (remaining > 0) return beneficiary.id
+  }
+
+  return null
+}


### PR DESCRIPTION
The webhook self-fetched /api/admin/blind-sponsorships/match, which had never worked in any deployment: NEXT_PUBLIC_SITE_URL is unset (codebase standardizes on NEXT_PUBLIC_BASE_URL) and the target route is gated by requireSuperAdmin, so an unauthenticated self-fetch was always 401/403.

Extract match logic into src/utils/blindSponsorships/match.ts with Result-shaped returns. Webhook now calls matchByStripeSubscriptionId directly using the existing service-role supabase client. Admin route remains gated by requireSuperAdmin and is now a thin Result→NextResponse wrapper.

Closes #100