### PR TITLE
feat(sponsorship): one-time gift option for open-sponsorship types

### DIFF
--- a/src/app/api/webhooks/stripe/route.ts
+++ b/src/app/api/webhooks/stripe/route.ts
@@ -536,6 +536,7 @@ export async function POST(req: Request) {
             )}/${interval}`,
             beneficiary_id: beneficiaryId || null,
             user_id: userId,
+            is_public: true,
           })
 
         if (activityError) {

--- a/src/app/sponsorships/components/HorizontalSponsorshipRow/index.tsx
+++ b/src/app/sponsorships/components/HorizontalSponsorshipRow/index.tsx
@@ -5,8 +5,13 @@ import { Beneficiaries } from "@/types"
 import { SponsoredBeneficiary } from "@/actions"
 import PortraitBeneficiaryCard from "../SponsorshipCard/PortraitCard"
 import SupportedRibbon from "@/components/common/SupportedRibbon"
+import SupportedCheckBadge from "@/components/common/SupportedCheckBadge"
 import type { BeneficiaryTabType } from "@/config/beneficiaryTypes"
-import { getApiTypes } from "@/config/beneficiaryTypes"
+import {
+  getApiTypes,
+  hasOpenSponsorshipSupport,
+  isOpenSponsorshipType,
+} from "@/config/beneficiaryTypes"
 
 // ---------------------------------------------------------------------------
 // StatsCard -- first item in the row; replaces the StatsSection above the fold
@@ -276,7 +281,12 @@ const HorizontalSponsorshipRow: React.FC<HorizontalSponsorshipRowProps> = ({
                   beneficiary={b}
                   onOpenDialog={() => onOpenModal(b)}
                   isSelected={selectedBeneficiaryId === b.id}
-                  imageOverlay={<SupportedRibbon />}
+                  imageOverlay={
+                    isOpenSponsorshipType(b.beneficiary_type) &&
+                    hasOpenSponsorshipSupport(b)
+                      ? <SupportedCheckBadge />
+                      : <SupportedRibbon />
+                  }
                   lastActivityAt={b.last_activity_at}
                 />
               ))}
@@ -294,7 +304,12 @@ const HorizontalSponsorshipRow: React.FC<HorizontalSponsorshipRowProps> = ({
                     beneficiary={b}
                     onOpenDialog={() => onOpenModal(b)}
                     isSelected={selectedBeneficiaryId === b.id}
-                    imageOverlay={<InNeedBadge />}
+                    imageOverlay={
+                      isOpenSponsorshipType(b.beneficiary_type) &&
+                      hasOpenSponsorshipSupport(b)
+                        ? <SupportedCheckBadge />
+                        : <InNeedBadge />
+                    }
                   />
                 ) : null,
               )}

--- a/src/app/sponsorships/components/SponsorshipActivity/index.tsx
+++ b/src/app/sponsorships/components/SponsorshipActivity/index.tsx
@@ -4,19 +4,15 @@ import Image from "next/image"
 import { Box, Text, Flex } from "@chakra-ui/react"
 import { Activity } from "@/types"
 
-// ---------------------------------------------------------------------------
-// Shared "Show more / Show less" button — exported so the modal's About
+// Shared "Show more / Show less" button, exported so the modal's About
 // section can use an identical style.
-// ---------------------------------------------------------------------------
 
 // Block-level, auto-width ghost pill. flex + w-fit keeps it as wide as its
 // content and forces it flush to the left edge of its container.
 export const SHOW_MORE_CLASS =
   "mt-2 flex w-fit items-center gap-1.5 text-sm font-semibold text-[#2b7ff9] px-3 py-1.5 rounded-lg bg-blue-50 hover:bg-blue-100 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-300"
 
-// ---------------------------------------------------------------------------
 // Time formatting
-// ---------------------------------------------------------------------------
 
 function formatRelativeTimeParts(dateStr: string): { main: string; sub: string } {
   const diff = Date.now() - new Date(dateStr).getTime()
@@ -43,9 +39,7 @@ function formatAbsoluteTime(dateStr: string): string {
   })
 }
 
-// ---------------------------------------------------------------------------
-// DateTooltip — relative date with absolute tooltip on hover
-// ---------------------------------------------------------------------------
+// DateTooltip, relative date with absolute tooltip on hover
 
 const DateTooltip: React.FC<{ dateStr: string }> = ({ dateStr }) => {
   const [visible, setVisible] = useState(false)
@@ -107,11 +101,9 @@ const DateTooltip: React.FC<{ dateStr: string }> = ({ dateStr }) => {
   )
 }
 
-// ---------------------------------------------------------------------------
-// ActivityRow — timeline layout:
+// ActivityRow timeline layout:
 //   Spine (24px): dashed blue line + dot on far left edge
-//   Content (flex): date inline with dot → title → description → thumbnails
-// ---------------------------------------------------------------------------
+//   Content (flex): date inline with dot, title, description, thumbnails
 
 const SPINE_W = "24px"
 const DESCRIPTION_CLAMP = 180
@@ -120,7 +112,7 @@ const THUMB_ASPECT = 140 / 110
 /** Full-width video rows below the image grid (typical wide video framing). */
 const VIDEO_ROW_ASPECT = 16 / 9
 
-// Height of the "incoming" line segment above the dot — matches one line of
+// Height of the "incoming" line segment above the dot, matches one line of
 // date text so the dot vertically aligns with the label beside it.
 const DOT_OFFSET_H = "14px"
 
@@ -128,187 +120,168 @@ interface ActivityRowProps {
   activity: Activity
   isFirst: boolean
   isLast: boolean
+  expanded: boolean
   onLightbox: (src: string) => void
 }
 
-const ActivityRow: React.FC<ActivityRowProps> = ({ activity, isFirst, isLast, onLightbox }) => {
-  const [expanded, setExpanded] = useState(true)
-
+const ActivityRow: React.FC<ActivityRowProps> = ({
+  activity,
+  isFirst,
+  isLast,
+  expanded,
+  onLightbox,
+}) => {
   const images = activity.images_url ?? []
   const videos = activity.videos_url ?? []
   const hasMedia = images.length > 0 || videos.length > 0
   const longDesc = (activity.description?.length ?? 0) > DESCRIPTION_CLAMP
-  /** Collapsed state hides media and may clamp text; toggle when either applies. */
-  const needsToggle = longDesc || hasMedia
 
   return (
-    // Fragment wraps the timeline row + the flush-left show more/less button.
-    <>
-      <Flex gap={0} align="stretch">
-        {/* ── Spine column — dot + dashed blue vertical line ── */}
+    <Flex gap={0} align="stretch">
+      <Box
+        w={SPINE_W}
+        flexShrink={0}
+        display="flex"
+        flexDirection="column"
+        alignItems="center"
+      >
         <Box
-          w={SPINE_W}
+          w="2px"
+          h={DOT_OFFSET_H}
           flexShrink={0}
-          display="flex"
-          flexDirection="column"
-          alignItems="center"
-        >
-          {/* Incoming segment: connects from previous entry's dot to this dot */}
-          <Box
-            w="2px"
-            h={DOT_OFFSET_H}
-            flexShrink={0}
-            style={{
-              borderLeft: isFirst ? "none" : "2px dashed #93c5fd",
-            }}
-          />
+          style={{
+            borderLeft: isFirst ? "none" : "2px dashed #93c5fd",
+          }}
+        />
 
-          {/* Dot */}
-          <Box
-            w="12px"
-            h="12px"
-            borderRadius="full"
-            bg="blue.400"
-            border="2px solid white"
-            flexShrink={0}
-            style={{ boxShadow: "0 0 0 2px #93c5fd" }}
-          />
+        <Box
+          w="12px"
+          h="12px"
+          borderRadius="full"
+          bg="blue.400"
+          border="2px solid white"
+          flexShrink={0}
+          style={{ boxShadow: "0 0 0 2px #93c5fd" }}
+        />
 
-          {/* Outgoing segment: fills remaining height, connects down to next entry */}
-          <Box
-            flex={1}
-            w="2px"
-            mt="2px"
-            style={{
-              borderLeft: isLast ? "none" : "2px dashed #93c5fd",
-            }}
-          />
-        </Box>
-
-        {/* ── Content column ── */}
         <Box
           flex={1}
-          minW={0}
-          pl={3}
-          pb={isLast ? 0 : 6}
-          display="flex"
-          flexDirection="column"
-          alignItems="flex-start"
-        >
-          {/* Date label — inline with the dot (same vertical band as DOT_OFFSET_H) */}
-          <Box h={DOT_OFFSET_H} display="flex" alignItems="center" mb={1}>
-            <DateTooltip dateStr={activity.created_at} />
-          </Box>
+          w="2px"
+          mt="2px"
+          style={{
+            borderLeft: isLast ? "none" : "2px dashed #93c5fd",
+          }}
+        />
+      </Box>
 
-          {activity.title && (
-            <Text className="text-gray-700 text-sm font-semibold mb-1 leading-snug">
-              {activity.title}
-            </Text>
-          )}
-
-          {activity.description && (
-            <Text
-              className="text-gray-700 text-sm leading-relaxed"
-              style={
-                !expanded && longDesc
-                  ? {
-                      display: "-webkit-box",
-                      WebkitLineClamp: 6,
-                      WebkitBoxOrient: "vertical",
-                      overflow: "hidden",
-                    }
-                  : undefined
-              }
-            >
-              {activity.description}
-            </Text>
-          )}
-
-          {/* Images: 3-column grid. Videos: full-width rows below. Hidden while collapsed. */}
-          {hasMedia && expanded && (
-            <Box w="100%" mt={3}>
-              {images.length > 0 && (
-                <Box
-                  display="grid"
-                  gridTemplateColumns="repeat(3, minmax(0, 1fr))"
-                  gap={2}
-                  w="100%"
-                >
-                  {images.map((url, i) => (
-                    <Box
-                      key={`img-${i}`}
-                      position="relative"
-                      w="100%"
-                      minW={0}
-                      aspectRatio={THUMB_ASPECT}
-                      borderRadius="md"
-                      overflow="hidden"
-                      cursor="zoom-in"
-                      onClick={() => onLightbox(url)}
-                    >
-                      <Image
-                        src={url}
-                        alt={`Update image ${i + 1}`}
-                        fill
-                        sizes="(max-width: 768px) 33vw, 200px"
-                        className="object-cover"
-                        unoptimized
-                      />
-                    </Box>
-                  ))}
-                </Box>
-              )}
-              {videos.length > 0 && (
-                <Flex
-                  direction="column"
-                  gap={2}
-                  w="100%"
-                  mt={images.length > 0 ? 2 : 0}
-                >
-                  {videos.map((url, i) => (
-                    <Box
-                      key={`vid-${i}`}
-                      w="100%"
-                      minW={0}
-                      aspectRatio={VIDEO_ROW_ASPECT}
-                      borderRadius="md"
-                      overflow="hidden"
-                      bg="blackAlpha.100"
-                    >
-                      <video
-                        src={url}
-                        controls
-                        preload="metadata"
-                        className="h-full w-full rounded-md object-contain"
-                        onError={(e) => { e.currentTarget.style.display = "none" }}
-                      />
-                    </Box>
-                  ))}
-                </Flex>
-              )}
-            </Box>
-          )}
+      <Box
+        flex={1}
+        minW={0}
+        pl={3}
+        pb={isLast ? 0 : 6}
+        display="flex"
+        flexDirection="column"
+        alignItems="flex-start"
+      >
+        <Box h={DOT_OFFSET_H} display="flex" alignItems="center" mb={1}>
+          <DateTooltip dateStr={activity.created_at} />
         </Box>
-      </Flex>
 
-      {/* Show more/less sits BELOW the timeline row, flush with the card's left edge */}
-      {needsToggle && (
-        <button
-          type="button"
-          onClick={() => setExpanded((v) => !v)}
-          className={SHOW_MORE_CLASS}
-        >
-          {expanded ? "Show less" : "Show more"}
-          <span aria-hidden>{expanded ? "▲" : "▼"}</span>
-        </button>
-      )}
-    </>
+        {activity.title && (
+          <Text className="text-gray-700 text-sm font-semibold mb-1 leading-snug">
+            {activity.title}
+          </Text>
+        )}
+
+        {activity.description && (
+          <Text
+            className="text-gray-700 text-sm leading-relaxed"
+            style={
+              !expanded && longDesc
+                ? {
+                    display: "-webkit-box",
+                    WebkitLineClamp: 6,
+                    WebkitBoxOrient: "vertical",
+                    overflow: "hidden",
+                  }
+                : undefined
+            }
+          >
+            {activity.description}
+          </Text>
+        )}
+
+        {hasMedia && expanded && (
+          <Box w="100%" mt={3}>
+            {images.length > 0 && (
+              <Box
+                display="grid"
+                gridTemplateColumns="repeat(3, minmax(0, 1fr))"
+                gap={2}
+                w="100%"
+              >
+                {images.map((url, i) => (
+                  <Box
+                    key={`img-${i}`}
+                    position="relative"
+                    w="100%"
+                    minW={0}
+                    aspectRatio={THUMB_ASPECT}
+                    borderRadius="md"
+                    overflow="hidden"
+                    cursor="zoom-in"
+                    onClick={() => onLightbox(url)}
+                  >
+                    <Image
+                      src={url}
+                      alt={`Update image ${i + 1}`}
+                      fill
+                      sizes="(max-width: 768px) 33vw, 200px"
+                      className="object-cover"
+                      unoptimized
+                    />
+                  </Box>
+                ))}
+              </Box>
+            )}
+            {videos.length > 0 && (
+              <Flex
+                direction="column"
+                gap={2}
+                w="100%"
+                mt={images.length > 0 ? 2 : 0}
+              >
+                {videos.map((url, i) => (
+                  <Box
+                    key={`vid-${i}`}
+                    w="100%"
+                    minW={0}
+                    aspectRatio={VIDEO_ROW_ASPECT}
+                    borderRadius="md"
+                    overflow="hidden"
+                    bg="blackAlpha.100"
+                  >
+                    <video
+                      src={url}
+                      controls
+                      preload="metadata"
+                      className="h-full w-full rounded-md object-contain"
+                      onError={(e) => {
+                        e.currentTarget.style.display = "none"
+                      }}
+                    />
+                  </Box>
+                ))}
+              </Flex>
+            )}
+          </Box>
+        )}
+      </Box>
+    </Flex>
   )
 }
 
-// ---------------------------------------------------------------------------
-// BeneficiaryActivity — manages list expansion + lightbox
-// ---------------------------------------------------------------------------
+// BeneficiaryActivity manages list expansion and lightbox.
 
 const COLLAPSED_COUNT = 2
 
@@ -317,14 +290,23 @@ interface BeneficiaryActivityProps {
 }
 
 const BeneficiaryActivity: React.FC<BeneficiaryActivityProps> = ({ activities }) => {
-  const [listExpanded, setListExpanded] = useState(true)
+  const [expanded, setExpanded] = useState(false)
   const [lightboxSrc, setLightboxSrc] = useState<string | null>(null)
 
   if (activities.length === 0) return null
 
-  const visible = listExpanded ? activities : activities.slice(0, COLLAPSED_COUNT)
-  const hasMore = activities.length > COLLAPSED_COUNT
-  const hiddenCount = activities.length - COLLAPSED_COUNT
+  const visible = expanded ? activities : activities.slice(0, COLLAPSED_COUNT)
+  const hasExpandableContent =
+    activities.length > COLLAPSED_COUNT ||
+    activities.some((activity) => {
+      const images = activity.images_url ?? []
+      const videos = activity.videos_url ?? []
+      return (
+        (activity.description?.length ?? 0) > DESCRIPTION_CLAMP ||
+        images.length > 0 ||
+        videos.length > 0
+      )
+    })
 
   return (
     <>
@@ -361,20 +343,20 @@ const BeneficiaryActivity: React.FC<BeneficiaryActivityProps> = ({ activities })
             activity={activity}
             isFirst={i === 0}
             isLast={i === visible.length - 1}
+            expanded={expanded}
             onLightbox={setLightboxSrc}
           />
         ))}
       </Box>
 
-      {hasMore && (
+      {hasExpandableContent && (
         <button
-          onClick={() => setListExpanded((v) => !v)}
+          type="button"
+          onClick={() => setExpanded((v) => !v)}
           className={SHOW_MORE_CLASS}
         >
-          {listExpanded
-            ? "Show less"
-            : `Show ${hiddenCount} more update${hiddenCount === 1 ? "" : "s"}`}
-          <span aria-hidden>{listExpanded ? "▲" : "▼"}</span>
+          {expanded ? "Show less" : "Show more"}
+          <span aria-hidden>{expanded ? "▲" : "▼"}</span>
         </button>
       )}
     </>

--- a/src/app/sponsorships/components/SponsorshipCard/index.tsx
+++ b/src/app/sponsorships/components/SponsorshipCard/index.tsx
@@ -10,7 +10,11 @@ import { getImageSrc, getThumbnailSrc } from "@/utils/supabase/media"
 import { ImageCarousel } from "@/components/common/ImageCarousel"
 import { PERSON_PLACEHOLDER_PATH } from "@/utils/placeholders"
 import SupportedRibbon from "@/components/common/SupportedRibbon"
-import { isOpenSponsorshipType } from "@/config/beneficiaryTypes"
+import SupportedCheckBadge from "@/components/common/SupportedCheckBadge"
+import {
+  hasOpenSponsorshipSupport,
+  isOpenSponsorshipType,
+} from "@/config/beneficiaryTypes"
 import { RIM_OVERLAY, CARD_SHADOW, CARD_SHADOW_SELECTED } from "./cardStyles"
 
 const BeneficiaryCard: React.FC<BeneficiaryCardProps> = ({
@@ -23,6 +27,7 @@ const BeneficiaryCard: React.FC<BeneficiaryCardProps> = ({
   const [images, setImages] = useState<BeneficiaryMedia[]>([])
 
   const isOpen = isOpenSponsorshipType(beneficiary.beneficiary_type)
+  const hasOpenSupport = isOpen && hasOpenSponsorshipSupport(beneficiary)
   const placeholderImage = PERSON_PLACEHOLDER_PATH
 
   useEffect(() => {
@@ -119,6 +124,7 @@ const BeneficiaryCard: React.FC<BeneficiaryCardProps> = ({
           }}
         />
 
+        {hasOpenSupport && <SupportedCheckBadge />}
         {!isOpen && beneficiary.status === "Budget Fulfilled" && <SupportedRibbon />}
 
         {/* Goal Badge — only show for fixed sponsorship types with a real goal */}

--- a/src/app/sponsorships/components/SponsorshipModal/index.tsx
+++ b/src/app/sponsorships/components/SponsorshipModal/index.tsx
@@ -141,6 +141,8 @@ const BeneficiaryModal: React.FC<BeneficiaryModalProps> = ({
   const [activeColumn, setActiveColumn] = useState<
     "monthly" | "one_time" | null
   >(isOpen ? "monthly" : null)
+  const [layoutVariant, setLayoutVariant] = useState<"split" | "simple">("split")
+  const [simpleFrequency, setSimpleFrequency] = useState<SponsorshipFrequency>("subscription")
   const [images, setImages] = useState<BeneficiaryMedia[]>([])
   const [imageLoading, setImageLoading] = useState<boolean>(false)
   const [videoUrl, setVideoUrl] = useState<string>(
@@ -778,7 +780,7 @@ const BeneficiaryModal: React.FC<BeneficiaryModalProps> = ({
 
     if (isOpen) {
       return (
-        <Box className="space-y-2">
+        <Box className="space-y-2 mt">
           <Text className="text-lg font-semibold text-gray-900">
             Support {firstName} with any amount
           </Text>
@@ -1055,6 +1057,207 @@ const BeneficiaryModal: React.FC<BeneficiaryModalProps> = ({
                     {/* AMOUNT INPUT — combined chips + custom field for open types, inline disabled input for fixed types. */}
                     {isOpen ? (
                       <Box className="text-left w-full">
+                        {/* Floating variant switcher — fixed to browser viewport bottom-right */}
+                        <Box
+                          position="fixed"
+                          bottom="24px"
+                          right="24px"
+                          zIndex={9999}
+                          bg="white"
+                          borderWidth="1px"
+                          borderColor="gray.200"
+                          borderRadius="2xl"
+                          boxShadow="2xl"
+                          overflow="hidden"
+                          minW="220px"
+                        >
+                          {/* Ribbon header */}
+                          <Box
+                            bg="amber.400"
+                            px={4}
+                            py={2}
+                            borderBottomWidth="1px"
+                            borderColor="amber.300"
+                          >
+                            <Text fontSize="xs" fontWeight="bold" color="amber.900" letterSpacing="wide" textTransform="uppercase">
+                              🧪 Layout Preview
+                            </Text>
+                            <Text fontSize="xs" color="amber.800" mt={0.5}>
+                              Toggle between checkout variants
+                            </Text>
+                          </Box>
+
+                          {/* Toggle buttons */}
+                          <Flex>
+                            {(["split", "simple"] as const).map((v) => (
+                              <Box
+                                key={v}
+                                as="button"
+                                flex={1}
+                                px={4}
+                                py={3}
+                                bg={layoutVariant === v ? "#2b7ff9" : "white"}
+                                color={layoutVariant === v ? "white" : "gray.500"}
+                                fontWeight={layoutVariant === v ? "semibold" : "medium"}
+                                fontSize="sm"
+                                transition="all 0.15s"
+                                _hover={{ bg: layoutVariant === v ? "#1a6fe0" : "gray.50" }}
+                                borderRightWidth={v === "split" ? "1px" : 0}
+                                borderColor="gray.200"
+                                onClick={() => setLayoutVariant(v)}
+                              >
+                                {v === "split" ? "Split" : "Simple"}
+                              </Box>
+                            ))}
+                          </Flex>
+                        </Box>
+
+                        {layoutVariant === "simple" ? (
+                          /* ── SIMPLE VARIANT ── */
+                          <Box>
+                            {/* Frequency toggle */}
+                            <Flex
+                              role="radiogroup"
+                              aria-label="Payment frequency"
+                              borderWidth="1px"
+                              borderColor="gray.300"
+                              borderRadius="xl"
+                              overflow="hidden"
+                              mb={3}
+                            >
+                              {openSponsorshipFrequencyOptions.map((opt) => {
+                                const isActive = simpleFrequency === opt.value
+                                return (
+                                  <Box
+                                    key={opt.value}
+                                    as="button"
+                                    flex={1}
+                                    h="44px"
+                                    display="flex"
+                                    alignItems="center"
+                                    justifyContent="center"
+                                    bg={isActive ? "#2b7ff9" : "white"}
+                                    color={isActive ? "white" : "gray.600"}
+                                    fontWeight={isActive ? "semibold" : "medium"}
+                                    fontSize="sm"
+                                    transition="background 0.15s"
+                                    _hover={{ bg: isActive ? "#1a6fe0" : "gray.50" }}
+                                    role="radio"
+                                    aria-checked={isActive}
+                                    borderRightWidth={opt.value === "subscription" ? "1px" : 0}
+                                    borderColor="gray.300"
+                                    onClick={() => {
+                                      setSimpleFrequency(opt.value)
+                                      setActiveColumn(opt.value === "subscription" ? "monthly" : "one_time")
+                                    }}
+                                  >
+                                    {opt.label}
+                                  </Box>
+                                )
+                              })}
+                            </Flex>
+
+                            {/* Bare amount input — no presets */}
+                            <Flex
+                              borderWidth="1px"
+                              borderColor="gray.300"
+                              borderRadius="xl"
+                              overflow="hidden"
+                              bg="white"
+                              align="center"
+                              h="52px"
+                              className="focus-within:border-[#2b7ff9] transition-colors"
+                            >
+                              <Box className="px-4 h-full flex items-center text-gray-400 font-medium border-r border-gray-200 text-sm select-none">
+                                $
+                              </Box>
+                              <Input
+                                type="number"
+                                step="0.01"
+                                autoFocus
+                                value={
+                                  simpleFrequency === "subscription"
+                                    ? (monthlyAmountCents > 0 ? monthlyAmountCents / 100 : "")
+                                    : (oneTimeAmountCents > 0 ? oneTimeAmountCents / 100 : "")
+                                }
+                                onChange={(e) => {
+                                  const dollars = parseFloat(e.target.value)
+                                  const cents = e.target.value === "" ? 0 : Number.isFinite(dollars) ? Math.round(dollars * 100) : 0
+                                  if (simpleFrequency === "subscription") {
+                                    setMonthlyAmountCents(cents)
+                                  } else {
+                                    setOneTimeAmountCents(cents)
+                                  }
+                                }}
+                                className="px-3 h-full border-0 outline-none focus:ring-0 text-base text-gray-700 flex-1"
+                                placeholder="Enter amount"
+                              />
+                            </Flex>
+
+                            {/* Single CTA */}
+                            <Tooltip
+                              content={simpleFrequency === "subscription" ? monthlyDisabledReason : oneTimeDisabledReason}
+                              showArrow
+                              disabled={!(simpleFrequency === "subscription" ? monthlyDisabledReason : oneTimeDisabledReason)}
+                              open={tipOpen}
+                              onOpenChange={(e) => setTipOpen(e.open)}
+                            >
+                              <Box
+                                as="span"
+                                display="block"
+                                width="100%"
+                                mt={3}
+                                tabIndex={0}
+                                onPointerDown={() => {
+                                  const reason = simpleFrequency === "subscription" ? monthlyDisabledReason : oneTimeDisabledReason
+                                  if (reason) setTipOpen(true)
+                                }}
+                              >
+                                <Button
+                                  onClick={() => handleStripePayment(simpleFrequency)}
+                                  loading={loadingFrequency === simpleFrequency}
+                                  loadingText="Processing..."
+                                  disabled={loading || (simpleFrequency === "subscription" ? !canPayMonthly : !canPayOneTime)}
+                                  width="100%"
+                                  h="auto"
+                                  minH="52px"
+                                  py={3}
+                                  px={3}
+                                  bg="#2b7ff9"
+                                  color="white"
+                                  fontWeight="semibold"
+                                  borderRadius="xl"
+                                  boxShadow="md"
+                                  _hover={{ bg: "#1a6fe0", boxShadow: "lg" }}
+                                  _disabled={{ bg: "#2b7ff9" }}
+                                  opacity={
+                                    (simpleFrequency === "subscription" ? !canPayMonthly : !canPayOneTime)
+                                      ? 0.5
+                                      : 1
+                                  }
+                                >
+                                  <Flex direction="column" align="center" gap={0.5} textAlign="center">
+                                    <Text fontWeight="semibold" fontSize="sm" lineHeight="short">
+                                      {simpleFrequency === "subscription"
+                                        ? `Sponsor ${firstName} 🪽`
+                                        : `Gift to ${firstName} 🪽`}
+                                    </Text>
+                                    <Text fontWeight="medium" fontSize="xs" opacity={0.9}>
+                                      {simpleFrequency === "subscription"
+                                        ? canPayMonthly
+                                          ? `$${(monthlyAmountCents / 100).toLocaleString(undefined, { maximumFractionDigits: 2 })}/month`
+                                          : "Monthly Sponsorship"
+                                        : canPayOneTime
+                                          ? `$${(oneTimeAmountCents / 100).toLocaleString(undefined, { maximumFractionDigits: 2 })} one-time`
+                                          : "One-Time Gift"}
+                                    </Text>
+                                  </Flex>
+                                </Button>
+                              </Box>
+                            </Tooltip>
+                          </Box>
+                        ) : (
+                        /* ── SPLIT VARIANT (existing two-column layout) ── */
                         <Flex
                           direction={{ base: "column", md: "row" }}
                           gap={{ base: 8, md: 16 }}
@@ -1241,6 +1444,7 @@ const BeneficiaryModal: React.FC<BeneficiaryModalProps> = ({
                             </Tooltip>
                           </Box>
                         </Flex>
+                        )} {/* end layoutVariant split */}
                       </Box>
                     ) : (
                       <Flex
@@ -1388,7 +1592,7 @@ const BeneficiaryModal: React.FC<BeneficiaryModalProps> = ({
                       )}
 
                     {/* Context copy inside the card */}
-                    <Box className="pt-4 mt-24 text-left">
+                    <Box className="pt-8 text-left">
                       {renderSponsorshipDisclaimer()}
                     </Box>
                   </>

--- a/src/app/sponsorships/components/SponsorshipModal/index.tsx
+++ b/src/app/sponsorships/components/SponsorshipModal/index.tsx
@@ -341,6 +341,8 @@ const BeneficiaryModal: React.FC<BeneficiaryModalProps> = ({
     isOpen && oneTimeAmountCents < MINIMUM_OPEN_SPONSORSHIP_CENTS
       ? OPEN_SPONSORSHIP_RANGE_MESSAGE
       : null
+  const oneTimeButtonDisabled =
+    loading || !canPayOneTime || activeColumn !== "one_time"
 
   const handleStripePayment = async (
     paymentType: SponsorshipFrequency = "subscription",
@@ -1233,14 +1235,11 @@ const BeneficiaryModal: React.FC<BeneficiaryModalProps> = ({
                                   loading={loadingFrequency === "one_time"}
                                   loadingText="Processing..."
                                   disabled={
-                                    loading ||
-                                    !canPayOneTime ||
-                                    activeColumn !== "one_time"
+                                    oneTimeButtonDisabled
                                   }
                                   width="100%"
                                   opacity={
-                                    activeColumn !== "one_time" ||
-                                    !canPayOneTime
+                                    oneTimeButtonDisabled
                                       ? 0.5
                                       : 1
                                   }
@@ -1260,7 +1259,7 @@ const BeneficiaryModal: React.FC<BeneficiaryModalProps> = ({
                                   }}
                                   _disabled={{ bg: "#EEF6FF" }}
                                 >
-                                  {canPayOneTime
+                                  {!oneTimeButtonDisabled
                                     ? `Gift $${(oneTimeAmountCents / 100).toLocaleString(undefined, { maximumFractionDigits: 2 })}`
                                     : "One-Time Gift"}
                                 </Button>

--- a/src/app/sponsorships/components/SponsorshipModal/index.tsx
+++ b/src/app/sponsorships/components/SponsorshipModal/index.tsx
@@ -40,11 +40,13 @@ import {
 } from "@/utils/supabase/media"
 import { ImageCarousel } from "@/components/common/ImageCarousel"
 import SupportedRibbon from "@/components/common/SupportedRibbon"
+import SupportedCheckBadge from "@/components/common/SupportedCheckBadge"
 import { PERSON_PLACEHOLDER_PATH } from "@/utils/placeholders"
 import { useSponsorship } from "../../hooks/useSponsorship"
 import BeneficiaryActivity, { SHOW_MORE_CLASS } from "../SponsorshipActivity"
 import { FAQModal } from "@/components/FAQModal"
 import {
+  hasOpenSponsorshipSupport,
   isOpenSponsorshipType,
   MINIMUM_OPEN_SPONSORSHIP_CENTS,
 } from "@/config/beneficiaryTypes"
@@ -112,6 +114,7 @@ const BeneficiaryModal: React.FC<BeneficiaryModalProps> = ({
   const user = useAuthStore((state) => state.user)
   const { setSponsorshipInProgress } = useSponsorship()
   const isOpen = isOpenSponsorshipType(beneficiary.beneficiary_type)
+  const hasOpenSupport = isOpen && hasOpenSponsorshipSupport(beneficiary)
 
   // For fixed types the budget_goal IS the sponsorship amount (set at create time).
   // For open types there is no goal — sponsors choose their own amount.
@@ -777,16 +780,39 @@ const BeneficiaryModal: React.FC<BeneficiaryModalProps> = ({
     )
 
     if (isOpen) {
+      const supportCopy = hasOpenSupport
+        ? {
+            heading: `${firstName} is already receiving support`,
+            body: (
+              <>
+                {firstName} is already receiving support, and additional gifts
+                help keep care steady for {firstName} and all children
+                receiving care. Your contribution strengthens daily meals,
+                health care, schooling, and the care team supporting them. You
+                will receive updates from our team as that support continues.
+              </>
+            ),
+          }
+        : {
+            heading: `Support ${firstName} with any amount`,
+            body: (
+              <>
+                Your contribution helps support {firstName} and all children
+                receiving care. Every gift strengthens daily care, meals, health
+                care, schooling, and the care team supporting them. You will
+                receive updates on {firstName}&apos;s progress directly from our
+                team.
+              </>
+            ),
+          }
+
       return (
         <Box className="space-y-2">
           <Text className="text-lg font-semibold text-gray-900">
-            Support {firstName} with any amount
+            {supportCopy.heading}
           </Text>
           <Text className="text-gray-700 leading-relaxed text-sm md:text-base">
-            Your contribution goes directly toward supporting {firstName}
-            &apos;s care and well-being. Every dollar makes a difference. You
-            will receive updates on {firstName}&apos;s progress directly from
-            our care team.
+            {supportCopy.body}
           </Text>
           <Box className="mt-5">{faqLink}</Box>
         </Box>
@@ -916,6 +942,7 @@ const BeneficiaryModal: React.FC<BeneficiaryModalProps> = ({
                       className="rounded-2xl aspect-[4/5] object-cover"
                       showArrowsOnHover={true}
                     />
+                    {hasOpenSupport && <SupportedCheckBadge size="lg" />}
                     {alreadyFulfilled && <SupportedRibbon size="lg" />}
                   </Box>
                 </Box>

--- a/src/components/HomeHero.tsx
+++ b/src/components/HomeHero.tsx
@@ -224,9 +224,14 @@ const HERO_CONTENT: Record<DisplayKey, HeroContent> = {
 // Nav links — derived from central config
 // ---------------------------------------------------------------------------
 
+const HIDDEN_HOME_LINK_TYPES = new Set<BeneficiaryTabType>(["IN_OUR_CARE"])
+
 const HERO_LINKS: { type: BeneficiaryTabType | null; label: string }[] =
   ALL_BENEFICIARY_TABS.filter(
-    (tab) => !tab.isLegacyAlias && tab.isPubliclyVisible,
+    (tab) =>
+      !tab.isLegacyAlias &&
+      tab.isPubliclyVisible &&
+      (tab.type === null || !HIDDEN_HOME_LINK_TYPES.has(tab.type)),
   ).map((tab) => ({
     type: tab.type,
     label: tab.label,

--- a/src/components/common/SupportedCheckBadge.tsx
+++ b/src/components/common/SupportedCheckBadge.tsx
@@ -1,0 +1,38 @@
+"use client"
+import React from "react"
+import { Flex } from "@chakra-ui/react"
+import { FaCircleCheck } from "react-icons/fa6"
+
+interface SupportedCheckBadgeProps {
+  size?: "sm" | "lg"
+}
+
+const SupportedCheckBadge: React.FC<SupportedCheckBadgeProps> = ({
+  size = "sm",
+}) => {
+  const isLarge = size === "lg"
+
+  return (
+    <Flex
+      position="absolute"
+      right={isLarge ? 4 : 2}
+      bottom={isLarge ? 4 : 2}
+      width={isLarge ? "42px" : "28px"}
+      height={isLarge ? "42px" : "28px"}
+      align="center"
+      justify="center"
+      bg="#2b7ff9"
+      color="white"
+      borderRadius="full"
+      border="2px solid white"
+      boxShadow="0 4px 12px rgba(0, 0, 0, 0.22)"
+      zIndex={10}
+      pointerEvents="none"
+      aria-label="Receiving support"
+    >
+      <FaCircleCheck size={isLarge ? 23 : 16} aria-hidden />
+    </Flex>
+  )
+}
+
+export default SupportedCheckBadge

--- a/src/config/beneficiaryTypes.ts
+++ b/src/config/beneficiaryTypes.ts
@@ -126,8 +126,8 @@ export const ALL_BENEFICIARY_TABS: BeneficiaryTypeConfig[] = [
   {
     label: "Rescue Dogs",
     type: "ANIMAL",
-    isOpenSponsorship: false,
-    defaultBudgetGoalCents: 2500,
+    isOpenSponsorship: true,
+    defaultBudgetGoalCents: -1,
     isPubliclyVisible: false, // coming soon
     singularName: "dog",
     pluralName: "dogs",
@@ -191,6 +191,23 @@ export function isOpenSponsorshipType(
   type: BeneficiaryTabType | string | null | undefined,
 ): boolean {
   return findConfig(type)?.isOpenSponsorship ?? false
+}
+
+export function isFixedSponsorshipType(
+  type: BeneficiaryTabType | string | null | undefined,
+): boolean {
+  const config = findConfig(type)
+  return Boolean(config?.type && !config.isOpenSponsorship)
+}
+
+export function hasOpenSponsorshipSupport(beneficiary: {
+  active_subscriptions?: number | null
+  budget_raised?: number | null
+}): boolean {
+  return (
+    Number(beneficiary.active_subscriptions ?? 0) > 0 ||
+    Number(beneficiary.budget_raised ?? 0) > 0
+  )
 }
 
 /**

--- a/src/config/beneficiaryTypes.ts
+++ b/src/config/beneficiaryTypes.ts
@@ -117,7 +117,7 @@ export const ALL_BENEFICIARY_TABS: BeneficiaryTypeConfig[] = [
     type: "IN_OUR_CARE",
     isOpenSponsorship: true,
     defaultBudgetGoalCents: -1,
-    isPubliclyVisible: true,
+    isPubliclyVisible: false, // hidden until beneficiaries are available
     singularName: "child",
     pluralName: "children",
     maxAgeYears: 14,

--- a/src/config/beneficiaryTypes.ts
+++ b/src/config/beneficiaryTypes.ts
@@ -117,7 +117,7 @@ export const ALL_BENEFICIARY_TABS: BeneficiaryTypeConfig[] = [
     type: "IN_OUR_CARE",
     isOpenSponsorship: true,
     defaultBudgetGoalCents: -1,
-    isPubliclyVisible: false, // hidden until beneficiaries are available
+    isPubliclyVisible: true,
     singularName: "child",
     pluralName: "children",
     maxAgeYears: 14,

--- a/supabase/migrations/20260526102932_open_sponsorship_support_states.sql
+++ b/supabase/migrations/20260526102932_open_sponsorship_support_states.sql
@@ -1,0 +1,18 @@
+BEGIN;
+
+UPDATE public.beneficiaries
+SET budget_goal = -1
+WHERE beneficiary_type IN ('SPECIAL_NEEDS', 'IN_OUR_CARE', 'ANIMAL')
+  AND budget_goal IS DISTINCT FROM -1;
+
+UPDATE public.beneficiaries
+SET status = CASE
+    WHEN COALESCE(active_subscriptions, 0) > 0
+      OR COALESCE(budget_raised, 0) > 0
+      THEN 'Partially Funded'::"PersonStatus"
+    ELSE 'New'::"PersonStatus"
+  END
+WHERE beneficiary_type IN ('SPECIAL_NEEDS', 'IN_OUR_CARE', 'ANIMAL')
+  AND status = 'Budget Fulfilled';
+
+COMMIT;


### PR DESCRIPTION
(AI Generated).

## Summary

* Merges the local open sponsorship support state work into this PR.
* Keeps the open sponsorship modal variants for split monthly and one time giving, plus the simple preview layout.
* Adds support state handling for open sponsorship types so supported children can remain fundable while showing a supported badge instead of the fixed sponsorship ribbon.
* Fixes the disabled one time gift CTA so it shows `One-Time Gift` instead of a stale amount like `Gift $33` when the button cannot be clicked.
* Collapses the latest updates card by default and keeps the shared show more styling aligned with the modal.
* Hides the In Our Care link from the home hero navigation while keeping the route and admin data model intact.

## What Changed

### Sponsorship modal

* Preserves separate monthly and one time amount state for open sponsorships.
* Keeps the split layout with independent preset pickers and CTA buttons.
* Keeps the simple layout preview with frequency selection, direct amount input, and one CTA.
* Gates the one time gift CTA label with the full disabled state, including loading, invalid amount, and inactive column state.
* Updates open sponsorship copy based on whether the child is already receiving support.

### Open sponsorship support states

* Adds `hasOpenSponsorshipSupport` as the shared helper for `active_subscriptions` and `budget_raised` based support detection.
* Adds `SupportedCheckBadge` for open sponsorship cards that are receiving support.
* Uses the supported check badge on sponsorship cards and horizontal rows for supported open sponsorships.
* Leaves fixed sponsorships using the existing fulfilled ribbon behavior.
* Makes Stripe webhook created sponsorship activities public.
* Adds a Supabase migration to set open sponsorship budget goals to `-1` and move fulfilled open sponsorship records back to `Partially Funded` or `New`.

### Sponsorship updates and navigation

* Updates the sponsorship activity timeline so expansion is controlled by the parent card instead of each row owning its own default expanded state.
* Keeps media hidden while updates are collapsed and expands all update media through the card level toggle.
* Hides In Our Care from the home hero link list without changing the public route.

## Root Cause Notes

* Open sponsorship records can receive support without becoming closed to future gifts, so the fixed sponsorship fulfilled ribbon was the wrong visual model for those cards.
* The one time gift button label only checked whether the amount was valid. It did not check whether the one time column was active or loading, so disabled inactive buttons could still show the selected amount.

## Validation

* `npm run lint`
* `npx tsc --noEmit`
* `npm run build`

## Review Notes

* PR branch: `feat/sponsorship-one-time-gift`
* Base branch: `dev`
* Merged local branch: `feature/open-sponsorship-support-states`
