### PR TITLE
Placeholder/unfinished: refactor(image-optimization): drop Supabase transforms, rely on Next.…

### DIFF
--- a/docs-findings.md
+++ b/docs-findings.md
@@ -1,0 +1,220 @@
+# Research Findings: Supabase Storage Transforms & Next.js Image Optimization
+
+> Compiled from official documentation. Date: 2026-05-26
+
+---
+
+## Table of Contents
+
+1. [Supabase Storage Image Transformations](#1-supabase-storage-image-transformations)
+2. [Next.js Image Optimization (`/_next/image`)](#2-nextjs-image-optimization-_nextimage)
+3. [Cross-Cutting Concerns: Supabase → Next.js Migration](#3-cross-cutting-concerns-supabase--nextjs-migration)
+4. [Source Index](#4-source-index)
+
+---
+
+## 1. Supabase Storage Image Transformations
+
+### Official Docs URL
+
+https://supabase.com/docs/guides/storage/serving/image-transformations
+
+### URL Format
+
+```
+GET https://<project-ref>.supabase.co/storage/v1/render/image/public/<bucket>/<path>?width=500&height=600
+```
+
+- **Public bucket route:** `/storage/v1/render/image/public/{bucket}/{path}`
+- **Signed/private route:** `/storage/v1/render/image/sign/{bucket}/{path}` (tokens appended as query params)
+- Query parameters are the transformation options.
+
+### Transformation Parameters
+
+| Parameter | Type / Values | Description |
+|-----------|--------------|-------------|
+| `width` | integer (1–2500) | Output width in pixels. |
+| `height` | integer (1–2500) | Output height in pixels. If only one is provided, the image is resized maintaining aspect ratio. |
+| `resize` | `cover` (default), `contain`, `fill` | Resize mode. `cover` = crop to fill dimensions; `contain` = fit inside dimensions (letterbox); `fill` = stretch to dimensions. |
+| `quality` | integer (1–100); default 75 | Output compression quality. |
+| `format` | `origin` or omitted | If omitted → auto-selects modern format (WebP for supporting clients). `origin` → forces original format. |
+
+> **Note on format auto-detection:** If the client sends `Accept: image/webp`, the transformed image is served as WebP automatically. AVIF is "coming soon." To force the original format, pass `format=origin`.
+
+### Plan Requirements
+
+> **"Image Resizing is currently enabled for Pro Plan and above."** — Official docs
+
+- Free tier: **not available.** Neither `render/image` endpoint nor Smart CDN are accessible.
+- Pro plan ($25/mo): enabled.
+- Billing: usage-based package pricing (per 1000 origin images). Each unique source image + unique set of transformation params counts as one "origin image."
+- Self-hosting option: deploy your own Imgproxy.
+
+### Limitations & Gotchas
+
+- **Width/height must be integers 1–2500.**
+- **Only WebP output supported for auto-format** (AVIF pending).
+- **Quality default is 75** — same as Next.js default.
+- **The `render/image` endpoint does not support the full public URL path** — you must prepend the Supabase project domain yourself. There is no relative-path shorthand.
+- **Transform endpoint does not respect `Cache-Control` headers from the origin image** in the same way as a direct object GET. Cache behavior is managed by the Smart CDN layer.
+- **Stale-image edge case:** Smart CDN caches transformed images. If you replace the source image, cached transforms may serve the old version until TTL expires (default configurable).
+
+### SDK Methods Return Transformed URLs
+
+The Supabase JS SDK's `getPublicUrl()` and `createSignedUrl()` both accept a `transform` options object that generates the appropriate `render/image/` URL.
+
+---
+
+## 2. Next.js Image Optimization (`/_next/image`)
+
+### Official Docs URLs
+
+- **Image Component (App Router):** https://nextjs.org/docs/app/api-reference/components/image
+- **Image Config (`next.config.js`):** https://nextjs.org/docs/app/api-reference/config/next-config-js/images
+- **Getting Started (Images):** https://nextjs.org/docs/app/getting-started/images
+- **Vercel Image Optimization (conceptual):** https://vercel.com/docs/image-optimization
+- **Limits & Pricing:** https://vercel.com/docs/image-optimization/limits-and-pricing
+- **Usage/Costs:** https://vercel.com/docs/image-optimization/managing-image-optimization-costs
+
+### URL Format (Internal Optimization Endpoint)
+
+The built-in Image Optimization API generates URLs in this format:
+
+```
+/_next/image?url=<encoded-source-url>&w=<width>&q=<quality>
+```
+
+- The `<url>` parameter is the **URL-encoded** source image URL (e.g., the Supabase public URL).
+- The `<w>` parameter is one of the configured `deviceSizes` or `imageSizes` widths (rounded to nearest match).
+- The `<q>` parameter is quality (default 75).
+
+When manually constructing these URLs, you must ensure the source image domain is listed in `remotePatterns` — otherwise Next.js returns a 400 Bad Request.
+
+### Image Component Props (Key Ones)
+
+| Prop | Values | Description |
+|------|--------|-------------|
+| `placeholder` | `"empty"` (default) or `"blur"` | Placeholder behavior while loading. |
+| `blurDataURL` | Data URL (base64) or path | Required when `placeholder="blur"` and the image is remote (not statically imported). Must be a tiny blurred preview. |
+| `loader` | Function `({ src, width, quality }) => string` | Custom URL resolver. Overrides the default `/_next/image` optimization for this component instance. |
+| `unoptimized` | `boolean` (default `false`) | When `true`, serves the source image as-is (no resizing, format conversion, or quality changes). |
+| `priority` | `boolean` | Preloads the image (skip lazy loading). Use for LCP images. |
+
+> **Note on `placeholder="blur"`:** For remote images, you must provide `blurDataURL` manually. Statically imported images get an automatic blurDataURL generated. Using a large blurDataURL (>~10KB) can hurt performance. Libraries like [Plaiceholder](https://plaiceholder.co) are commonly used for generation.
+
+### `next.config.js` — Image Configuration
+
+```js
+// next.config.js
+const config = {
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: '*.supabase.co',
+        port: '',
+        pathname: '/storage/v1/render/image/public/**',
+        search: '',
+      },
+    ],
+    deviceSizes: [640, 750, 828, 1080, 1200, 1920, 2048, 3840],  // default
+    imageSizes: [16, 32, 48, 64, 96, 128, 256, 384],              // default
+    formats: ['image/webp', 'image/avif'],                          // default
+    minimumCacheTTL: 3600,                                          // default on Vercel
+  },
+}
+```
+
+**Key details about `remotePatterns`:**
+- Each pattern requires `protocol` and `hostname`.
+- `hostname` supports glob patterns: `*.supabase.co`, `**.supabase.co`.
+- `pathname` supports glob patterns: `/storage/v1/render/**`.
+- If `search` is set to `''` (empty string), **no query parameters are allowed** on the source URL. Omit `search` or set it to `'?'` to allow any query params.
+- `remotePatterns` **replaced** the older `domains: [...]` array in Next.js 13+. `domains` is deprecated.
+
+### Cache Behavior (Vercel)
+
+| Setting | Default | Notes |
+|---------|---------|-------|
+| `minimumCacheTTL` | 3600s (1 hour) | Next.js configuration. Determines max-age of optimized images. |
+| Vercel CDN TTL | Uses upstream `Cache-Control max-age` or `minimumCacheTTL`, **whichever is larger** | Source: https://vercel.com/docs/image-optimization |
+| Optimized image size limit | 10 MB | Source: Vercel Limits docs |
+| Source image max dimensions | 8192 × 8192 px | Source: Vercel Limits docs |
+
+> **Key insight:** If the upstream image (Supabase) has no `Cache-Control` header or a very short one, Next.js falls back to `minimumCacheTTL` (1h). You can increase `minimumCacheTTL` to 31 days (`2678400`) if images are static, to reduce optimization costs.
+
+### Pricing & Limits (Vercel Image Optimization)
+
+| Plan | Included Source Images | Overage |
+|------|----------------------|---------|
+| Hobby (Free) | 1,000 source images/mo | Pay-as-you-go |
+| Pro ($20/mo) | 5,000 source images/mo | $5 per 1,000 additional |
+
+> **Important:** Each unique source image URL that gets optimized counts against this quota **once per cache-miss lifecycle** — re-optimization for an already-cached image doesn't re-count. But any new transformation dimensions count as new source images.
+
+---
+
+## 3. Cross-Cutting Concerns: Supabase → Next.js Migration
+
+### What changes when moving to Next.js-only optimization
+
+**Current setup (likely):** `<Image src={supabaseRenderUrl} ...>` where `supabaseRenderUrl` already includes transformation params. Next.js may or may not be re-optimizing these.
+
+**Proposed setup:** `<Image src={publicUrl} ...>` where `publicUrl` is the **raw** Supabase object URL (no `render/image/` transform). Let Next.js handle all resizing/format/quality.
+
+### Gotchas & Caveats
+
+1. **Supabase Pro requirement goes away** — Image transformations handled by Next.js/Vercel, not Supabase. You can stay on Supabase Free plan for storage.
+
+2. **Vercel Image Optimization costs are real** — If you have many unique images × many sizes, the "source image" quota can burn quickly. Each responsive variant doesn't re-count, but each unique original does.
+
+3. **`remotePatterns` must be precise** — The current config uses `hostname: "*.supabase.co"`. This is sufficient for raw object URLs at `https://<project>.supabase.co/storage/v1/object/public/...`. **But** if you want to keep using the Supabase `render/image` transform URLs as Next.js *source* URLs, they must also be in `remotePatterns` (they go through the same Next.js optimization pipeline).
+
+4. **Automatic format negotiation** — Supabase `render/image` auto-selects WebP via `Accept` header. Next.js does the same (to `format: ['image/webp', 'image/avif']`) **plus** generates AVIF if supported. Next.js actually wins here.
+
+5. **blurDataURL for remote images** — If you want `placeholder="blur"`, you need a generated base64 blur hash per image. This means server-side processing (e.g., on upload, or at request time). Supabase doesn't provide blur hashes natively. Plaiceholder or a custom Edge Function would be needed.
+
+6. **Cache layering** — With Supabase transforms + Next.js re-optimization, images go through: Supabase Smart CDN → Vercel Edge → Browser. This is two cache hops. If Next.js is handling everything, it's: Supabase origin (no cache) → Vercel Edge → Browser. Simpler, but puts more load on Vercel.
+
+7. **Signed/private images** — The `render/image/sign/` endpoint for private buckets adds auth tokens. Next.js Image Optimization can't authenticate those requests unless you implement a custom loader that attaches the token server-side. This is a significant complexity add.
+
+8. **Width limit differences** — Supabase caps at 2500px; Next.js (Vercel) caps at 8192px. Not likely an issue, but worth noting.
+
+9. **Default quality** — Both default to 75. Consistent.
+
+10. **`unoptimized` for small/vector images** — Vercel recommends using `unoptimized` for images under 10 KB, SVG, and animated GIF to avoid unnecessary optimization costs.
+
+---
+
+## 4. Source Index
+
+### Supabase
+
+| Page | URL | Key Content |
+|------|-----|-------------|
+| Storage Image Transformations | https://supabase.com/docs/guides/storage/serving/image-transformations | Primary docs: parameters, URL format, Pro requirement, Next.js loader example |
+| Manage Storage Image Transformations usage | https://supabase.com/docs/guides/platform/manage-your-usage/storage-image-transformations | Billing details (per 1000 origin images, package pricing) |
+| Features: Image Transformations | https://supabase.com/features/image-transformations | Marketing overview, mentions Imgproxy self-hosting |
+| Blog: Storage v2 (Smart CDN + resizing) | https://supabase.com/blog/storage-image-resizing-smart-cdn | Original announcement, explains stale-cache edge case |
+| Blog: Storage v3 (quality & format) | https://supabase.com/blog/storage-v3-resumable-uploads | Added `quality` and `format` parameters, Next.js loader example |
+| GitHub source (.mdx) | https://github.com/supabase/supabase/blob/master/apps/docs/content/guides/storage/serving/image-transformations.mdx | Raw source of the docs page |
+
+### Next.js / Vercel
+
+| Page | URL | Key Content |
+|------|-----|-------------|
+| Image Component (App Router) | https://nextjs.org/docs/app/api-reference/components/image | Full API reference: all props (`placeholder`, `blurDataURL`, `loader`, `unoptimized`, `priority`, `sizes`, etc.) |
+| Image Config (`next.config.js`) | https://nextjs.org/docs/app/api-reference/config/next-config-js/images | `remotePatterns`, `deviceSizes`, `imageSizes`, `formats`, `minimumCacheTTL`, `loaderFile` |
+| Getting Started: Images | https://nextjs.org/docs/app/getting-started/images | Quickstart, explains `remotePatterns` and why it's required |
+| Vercel Image Optimization | https://vercel.com/docs/image-optimization | Overview, caching behavior, TTL logic, custom loader support |
+| Limits & Pricing | https://vercel.com/docs/image-optimization/limits-and-pricing | Source image dimension limits (8192px), max optimized size (10MB), quotas per plan |
+| Managing Usage & Costs | https://vercel.com/docs/image-optimization/managing-image-optimization-costs | Cost-saving tips: `unoptimized` for small images, caching strategy, `minimumCacheTTL` |
+| Vercel Changelog (Hobby limits increased) | https://vercel.com/changelog/increased-hobby-usage-limits-for-image-optimization | Current Hobby tier limits |
+| `next-image-unconfigured-host` error | https://nextjs.org/docs/messages/next-image-unconfigured-host | Explains the `search: ''` gotcha and `remotePatterns` |
+
+### Additional References
+
+| Page | URL | Why |
+|------|-----|-----|
+| Nuxt Image - Supabase Provider | https://image.nuxt.com/providers/supabase | Confirms Supabase resize modes (`cover`, `contain`, `fill`) |
+| Plaiceholder | https://plaiceholder.co | Recommended by Next.js docs for `blurDataURL` generation |

--- a/next.config.ts
+++ b/next.config.ts
@@ -36,6 +36,7 @@ const nextConfig: NextConfig = {
   },
 
   images: {
+    minimumCacheTTL: 604800, // 7 days — static beneficiary photos rarely change
     remotePatterns: [
       {
         protocol: "https",

--- a/nextjs-image-transformation.md
+++ b/nextjs-image-transformation.md
@@ -1,0 +1,182 @@
+# Proposal: Replace Supabase Image Transformations with Next.js Image Optimization
+
+**Status:** Tentative (updated with review findings)
+**Reviewed by:** 3 subagent reviews + official docs exploration
+**Date:** 2026-05-26
+**Reference docs:** `docs-findings.md` (raw documentation compilation)
+
+---
+
+## Problem
+
+Supabase Image Transformation (the `/render/image/` endpoint) is a Pro-plan-only feature. The free development Supabase project cannot serve transformed images, causing inconsistent behavior:
+
+- **Development (free plan):** Direct storage URLs via `/storage/v1/object/public/` — images display at original resolution
+- **Production (paid plan):** Transformed URLs via `/render/image/` — WebP, resized, quality-optimized
+
+Current workaround (just implemented): a `NEXT_PUBLIC_ENABLE_IMAGE_TRANSFORMS` feature flag that conditionally enables transforms. On dev, thumbnails are disabled entirely.
+
+### Additionally: we are currently double-optimizing
+
+Every image today goes through **both** Supabase transforms **and** Next.js `/_next/image`:
+
+```
+Supabase original → Supabase /render/image (transform #1) → Vercel /_next/image (transform #2) → browser
+```
+
+This is wasteful — two optimization passes for the same image, burning both Supabase origin-image quota and Vercel source-image quota unnecessarily.
+
+---
+
+## Proposal
+
+Eliminate Supabase Image Transformation entirely. Serve all images as direct `/storage/v1/object/public/` URLs, and rely solely on Next.js `<Image>`'s built-in optimization (`/_next/image`) for resizing, format conversion (WebP), and quality control.
+
+The new pipeline:
+
+```
+Supabase original → Vercel /_next/image (single transform) → browser
+```
+
+## How It Would Work
+
+| Concern | Current (Supabase transform) | Proposed (Next.js only) |
+|---------|------------------------------|------------------------|
+| Resizing | Supabase `/render/image/` endpoint | Next.js `/_next/image` edge CDN |
+| Format (WebP) | Supabase auto-converts | Next.js auto-converts (browser negotiation, also supports AVIF) |
+| Quality | Supabase param | Next.js `?q=` param (both default to 75) |
+| Thumbnail (blur-up) | 40x40 Supabase-transformed + CSS blur | `/_next/image?w=16&q=20` + CSS blur |
+| Cost | None — Supabase Pro kept for DB, transforms are a bundled perk | Vercel quota unchanged (already burning it today) |
+| Dev/prod parity | Different behavior per env | Identical everywhere |
+
+## Changes Required
+
+### 1. `src/utils/supabase/media.ts`
+
+- **`buildStorageUrl`**: Remove the Supabase-transform branch entirely. Always construct the direct `/storage/v1/object/public/` URL.
+- **`generatePublicUrl`**: Unchanged signature, always returns direct URL. Remove `NEXT_PUBLIC_ENABLE_IMAGE_TRANSFORMS` check.
+- **`generateThumbnailUrl`**: Return an `/_next/image?w=16&q=20&url=<encoded-direct-url>` URL using the server-side URL constructor for safe encoding. Include the `unoptimized` caveat documentation.
+
+### 2. `src/utils/supabase/imageTransform.ts`
+
+- **`getTransformedImageUrl`**: Strip transform logic, return direct URL always. **Note: still actively called** from `src/app/api/admin/beneficiaries/images/create/route.ts` for the API response `public_url` field. After change, the response will contain a direct URL instead of a Supabase-transform URL. The admin upload handler consumes this for immediate display only — no stored dependency — so it's safe.
+- **`getImageVariants`**: Remove (all variants point to the same URL — no value). Zero callers in the codebase.
+- **`getSignedTransformedUrl`**: Remove (private bucket transform — not used). Zero callers.
+- **`uploadImageForTransformation`**, **`uploadImagesForTransformation`**, **`deleteTransformedImages`**: These are storage operations unrelated to transforms. Evaluate whether they have value as standalone upload helpers; if not, remove them too.
+
+### 3. Feature flag
+
+- Remove `NEXT_PUBLIC_ENABLE_IMAGE_TRANSFORMS` from code and `dotenv.sample`. No longer needed.
+
+### 4. `next.config.ts`
+
+- No `remotePatterns` change needed — the existing `hostname: "*.supabase.co"` glob already covers `/storage/v1/object/public/**`.
+- **Add `images.minimumCacheTTL`** to extend cache lifetime and reduce Vercel source-image quota burn:
+  ```ts
+  images: {
+    minimumCacheTTL: 604800, // 7 days for static beneficiary photos
+    // ... existing remotePatterns
+  }
+  ```
+- Explicitly document which `imageSizes` will be used for thumbnails (add a comment).
+
+### 5. `ProgressiveImage.tsx`
+
+- No structural changes needed. Already handles missing thumbnails gracefully.
+- **Defensive fix (recommended):** Replace the `unoptimized={isThumbnailLocal}` heuristic with an explicit `unoptimized={true}` prop on the thumbnail `<Image>`. The existing heuristic works only because `/_next/image` URLs start with `/`, but this is fragile.
+
+### 6. Email exception — keep Supabase transforms for email only
+
+Email clients render raw `<img>` tags with no Next.js `/_next/image` wrapper. Without Supabase transforms, emails would embed full-resolution originals (potentially 500KB+ JPEGs instead of 50KB WebP).
+
+**Approach:** Create a separate email-specific helper that uses the Supabase transform endpoint. The main rendering pipeline (`media.ts`, `imageTransform.ts`) drops Supabase transforms entirely.
+
+```typescript
+// src/utils/supabase/email-images.ts
+import { createClient } from "@/utils/supabase/client"
+import { STORAGE_BUCKET } from "@/utils/supabase/buckets"
+import { getStorageKey, type MediaRow } from "@/utils/supabase/media"
+
+export function getEmailImageUrl(media: MediaRow): string {
+  const key = getStorageKey(media)
+  const { data } = createClient().storage
+    .from(STORAGE_BUCKET)
+    .getPublicUrl(key, {
+      transform: { width: 800, height: 800, quality: 85, resize: "cover" },
+    })
+  return data.publicUrl
+}
+```
+
+This is a net-zero complexity change — we replace one function call in `email.ts` with another, and the Supabase transform logic lives in exactly one file with a clearly scoped purpose.
+
+## Cost Impact
+
+**No direct cost savings from this change.** The Supabase Pro plan ($25/mo) is kept for database hosting — image transforms are a bundled perk that comes with it, not the reason for the plan. Vercel Pro ($20/mo) is also already in place. Both continue as-is.
+
+What we do gain:
+
+1. **Eliminate double-optimization waste.** Every image today passes through Supabase transforms **and then** Next.js `/_next/image` — two separate optimizations for the same image. This burns Vercel source-image quota unnecessarily. After the change, each image counts as ~2 source images for a *different reason* (thumbnail + main display), but the total quota burn is the same or slightly lower since we remove the Supabase transform overhead.
+
+2. **Dev/prod parity.** No more conditional code paths, no more feature flag, no more broken thumbnails on dev.
+
+3. **Simpler code.** Remove the feature flag, remove unused exports (`getImageVariants`, `getSignedTransformedUrl`, etc.), remove the Supabase transform branch from `buildStorageUrl`.
+
+**Vercel source-image quota per original:** The thumbnail (`/_next/image?w=16&q=20`) and main image (`/_next/image?w=...&q=75`) use the same source URL with different widths. Vercel counts each unique (source URL + dimensions) pair as one source image. Each beneficiary photo burns **~2 source-image quota per cache-miss lifecycle** (one for thumbnail, one for main display). This is the same as today's behavior, just structured differently.
+
+**Cold-cache latency:** The proposed approach fetches larger originals from Supabase (untransformed JPEG/PNG ~100-500KB vs ~30-60KB WebP). This adds ~50-100ms on the **first uncached request** per image while Vercel downloads and processes the original. After Vercel edge caches, latency is identical. Imperceptible at this traffic level.
+
+## Deployment Sequence (Recommended)
+
+**Phase 1 — Config hardening (no behavior change):**
+- Add explicit `pathname: '/storage/v1/object/public/**'` to the Supabase `remotePatterns` entry in `next.config.ts`
+- Set `minimumCacheTTL: 604800`
+- Deploy and verify no regression
+
+**Phase 2 — Migration (flag-gated):**
+- Deploy the code changes behind the existing `NEXT_PUBLIC_ENABLE_IMAGE_TRANSFORMS` check — production still has the flag `true`, so behavior doesn't change
+- Set the flag to `false` on staging/dev and verify end-to-end
+
+**Phase 3 — Toggle & cleanup:**
+- Toggle `NEXT_PUBLIC_ENABLE_IMAGE_TRANSFORMS=false` on production
+- Monitor for 24-48 hours
+- Remove the flag from code, `dotenv.sample`, and all env configs
+
+## Edge Cases & Risks (from review)
+
+### Corrected from original plan
+
+| Issue | Original claim | Corrected fact |
+|-------|---------------|----------------|
+| Thumbnail width | `/_next/image?w=20` | `w=16` — rounds to nearest `imageSizes` entry (16, 32, 48...) |
+| Cost | "Free (Vercel edge)" | Has source-image quotas (1,000/mo Hobby, 5,000/mo Pro) |
+| `getTransformedImageUrl` removal | "Remove transform logic" | Function is active in admin upload route (still safe, just a different URL shape) |
+| `next.config.ts` | "if any config is needed" | Needs `minimumCacheTTL` — potentially material cost impact |
+| Dev mode | Not mentioned | `/_next/image` does NOT transform in `next dev` — thumbnails serve at full resolution. CSS blur still works, but wasteful. |
+
+### Open risks
+
+1. **Manual `/_next/image` URL construction** — Must use safe URL encoding server-side. Malformed paths could 400 from the optimization endpoint.
+2. **`unoptimized` guard fragility** — ProgressiveImage's thumbnail `<Image>` relies on `startsWith('/')` to set `unoptimized={true}`. Works for now, but fragile.
+3. **Email image sizes** — `src/utils/email.ts` gets full-res originals instead of 800x800 WebP. Likely fine but verify.
+4. **Rollback cache** — Rolled-back code would see 404s on cached `/_next/image` URLs. Transient — clients re-render within one cycle.
+5. **`next dev`** — Thumbnails load at full resolution (no `/render/image` *and* no `/_next/image` resize). CSS blur still applies.
+
+### Confirmed safe (from review)
+
+- `getSignedTransformedUrl` — zero callers in codebase ✅
+- `getImageVariants` — zero callers in codebase ✅
+- CORS — server-to-server fetch, not browser CORS concern ✅
+- `remotePatterns` — existing `*.supabase.co` wildcard covers both old and new paths ✅
+- ProgressiveImage race conditions — pre-existing, benign ✅
+
+## Files to Modify
+- `src/utils/supabase/media.ts`
+- `src/utils/supabase/imageTransform.ts`
+- `next.config.ts`
+- `dotenv.sample`
+- `src/components/common/ProgressiveImage.tsx` (optional: `unoptimized` hardening)
+
+## Files to Remove
+- `getImageVariants`, `getSignedTransformedUrl`, `deleteTransformedImages` from `imageTransform.ts`
+- `uploadImageForTransformation`, `uploadImagesForTransformation` (if not used elsewhere)

--- a/review-costs.md
+++ b/review-costs.md
@@ -1,0 +1,323 @@
+# Cost & Architecture Review: Supabase Transforms → Next.js Image Optimization
+
+Date: 2026-05-26
+Reviewed: `nextjs-image-transformation.md` (plan) against `docs-findings.md` (reference)
+
+---
+
+## 1. Current Cost Baseline
+
+### Current Stack
+- **Supabase:** Pro plan ($25/mo) — image transforms are a Pro-only feature
+- **Vercel:** Presumably Hobby ($0/mo) or Pro ($20/mo)
+- **The problem:** The current codebase **double-optimizes every image.** Here's the proof:
+
+#### Evidence of double optimization
+
+**`ProgressiveImage.tsx`** — the main image's `src` goes through `<Image>` component:
+```tsx
+// ProgressiveImage.tsx — main image
+<Image src={displaySrc} ... unoptimized={isLocalImage} />
+```
+`isLocalImage` is false for external Supabase URLs, so `unoptimized=false`. This means the current flow is:
+
+```
+Supabase original → Supabase render/image (transform #1) → Vercel /_next/image (transform #2) → browser
+```
+
+The **thumbnail** uses the same pattern:
+```tsx
+<Image src={thumbnailSrc} ... unoptimized={isThumbnailLocal} />
+```
+Same double-transform pipeline, just for a 40×40 image.
+
+This means:
+- **Supabase billing:** Each unique original + unique transform params = 1 "origin image" billed
+- **Vercel billing:** Each unique source URL (the Supabase render URL) + each requested width = Vercel source image quota consumed
+- **Bandwidth waste:** Supabase sends a transformed image to Vercel, Vercel re-downloads and re-transforms it
+
+### Current estimated monthly cost (wasteful baseline)
+
+| Item | Cost | Notes |
+|------|------|-------|
+| Supabase Pro plan | $25/mo | Required for transforms |
+| Supabase origin images | $0? | Depends on usage, but tier likely included in $25 plan |
+| Vercel image opt (waste) | ~$0–$5/mo | Currently burning quota on already-transformed images |
+| **Total current (wasteful)** | **~$25/mo** | |
+
+---
+
+## 2. Proposed Cost (Next.js-Only Optimization)
+
+### Source image count estimate
+
+Based on codebase analysis:
+- **Private bucket (public-facing images):** Beneficiaries have 1–5 images each via `ImageCarousel`. If 50–100 beneficiaries → **50–500 source images**
+- **Admin images:** `BeneficiaryCard` (admin) uses `unoptimized` — *does not consume Vercel quota*
+- **Activities/media images:** Additional images per activity entry → another 50–200 images
+
+**Total source images:** ~100–700 unique originals
+
+### Vercel quota consumption
+
+Vercel counts source images **per width requested, per cache-miss lifecycle**. Key multiplier:
+
+| Size | Source image count per original |
+|------|-------------------------------|
+| Thumbnail (w=20, q=20) | 1 (different width = different source image) |
+| Main display (w=800, default) | 1 (different width) |
+| Other responsive sizes | ~1–2 more if `sizes` triggers different widths |
+| **Total per original** | **~2–3 per cache lifecycle** |
+
+**Estimated monthly quota burn:** 100–700 originals × 2–3 sizes = **200–2,100 source images/mo**
+
+### Vercel plan comparison
+
+| Plan | Included images | Monthly cost | Overages | Fits? |
+|------|----------------|-------------|----------|-------|
+| **Hobby** ($0) | 1,000/mo | $0 | Pay-as-you-go (rate unclear) | Tight — 200–2,100 is risky if traffic grows or many images |
+| **Pro** ($20/mo) | 5,000/mo | $20 | $5/1k images | Comfortable — 5× headroom |
+| **Pro + overage** | any | $20–$30 | If 2,100+ primary images needed | Unlikely to reach |
+
+### Can we stay on Hobby?
+
+**Yes, with mitigation.** The risk is the thumbnail generating a second cache-miss per image (doubling quota). Mitigations:
+
+1. **Set `minimumCacheTTL` to 604800 (7 days)** in `next.config.ts` — extends cache lifespans so visitors share cache hits longer
+2. **Skip thumbnail optimization on Hobby** — fall back to no thumbnail for low traffic, or generate thumbnails once via a build-time script
+3. **Use `unoptimized` for non-critical images** — admin images already do this
+
+**Risk scenario on Hobby:** If 200 unique images × 2 sizes = 400/month baseline, and monthly traffic causes enough cache-misses to re-trigger 300 images, you're at 700/1,000. Safe. But if you add 100 more beneficiaries with 5 images each × 2 sizes = 1,000 more, you're over.
+
+---
+
+## 3. Latency: Extra Network Hop
+
+### Current flow
+```
+Browser → Vercel edge → Supabase Smart CDN → Vercel edge → browser
+```
+Wait — the current flow is actually *worse* than proposed. Let me trace it properly.
+
+### Current: Supabase transforms → Next.js `/_next/image`
+
+| Step | Party | What happens | Latency |
+|------|-------|-------------|---------|
+| 1 | Browser | Requests page, Next.js renders `<Image src={supabaseRenderUrl}>` | — |
+| 2 | Vercel edge | Sees unoptimized external URL, fetches it | ~100ms |
+| 3 | Supabase | Supabase Smart CDN may have cached transform, or hits origin | ~50-200ms |
+| 4 | Vercel edge | Receives Transformed WebP, re-optimizes (resize/quality) | ~50-100ms processing |
+| 5 | Vercel edge | Serves optimized image to browser | ~20-50ms |
+| **Total uncached** | | | **~200-450ms** |
+
+### Proposed: Direct storage URL → Next.js `/_next/image`
+
+| Step | Party | What happens | Latency |
+|------|-------|-------------|---------|
+| 1 | Browser | Requests page, Next.js renders `<Image src={directUrl}>` | — |
+| 2 | Vercel edge | Sees unoptimized external URL, fetches it | ~100ms |
+| 3 | Supabase | Serves original (no Smart CDN transform cache hit) | ~50-150ms |
+| 4 | Vercel edge | Optimizes (resize + WebP conversion) | ~50-150ms (more work: original is bigger) |
+| 5 | Vercel edge | Serves to browser | ~20-50ms |
+| **Total uncached (proposed)** | | | **~220-450ms** |
+
+### Cached comparison (both flows)
+
+| State | Current | Proposed |
+|-------|---------|----------|
+| **Hot cache** (Vercel edge cached) | ~20-50ms | ~20-50ms |
+| **Warm cache** (Supabase CDN cached, Vercel miss) | ~150-250ms | ~300-400ms (bigger original to process) |
+| **Cold cache** (both miss) | ~200-450ms | ~220-450ms |
+
+**Verdict:** The proposed flow is **marginally slower only on Vercel cache miss** because the original image from Supabase is larger (untransformed) — Vercel has to download and process more data. But the difference is ~50-100ms on first load, which is imperceptible. After cache is warm, identical.
+
+**For this project's traffic level** (charity sponsorship platform, likely hundreds to low thousands of visitors/month), the latency difference is negligible. Users arrive organically through shares/links, so a 100ms slower first load on a single page is invisible.
+
+---
+
+## 4. Bandwidth Costs
+
+### Supabase → Vercel (origin fetch)
+
+| Aspect | Current | Proposed | Delta |
+|--------|---------|----------|-------|
+| Image size transferred | Transformed WebP (~30-60KB) | Original JPEG/PNG (~100-500KB) | **2-10× more per request** |
+| Number of transfers | Each cache miss at Vercel | Each cache miss at Vercel | Same count |
+| Cost | Varies by Supabase plan egress | Varies by Supabase plan egress | **Higher egress from Supabase** |
+
+Supabase storage egress pricing: Pro plan includes 100GB egress (or tier-appropriate amount). For a low-traffic site, the difference between 50MB/mo and 200MB/mo in origin-fetch bandwidth is **not material** — both are well within any Pro tier's included limits.
+
+### Vercel → Browser
+
+Vercel edge bandwidth is included in all plans (Hobby: 100GB, Pro: 1TB). The optimized output size is essentially the same (both produce WebP at ~75 quality), so no meaningful difference here.
+
+### Cross-region costs
+
+The Vercel project deploys to `sfo1` (San Francisco, per `vercel.json`). If the Supabase project is also in `us-west-1` (Oregon) or `us-west-2` (Oregon), traffic between Vercel and Supabase stays within the US West coast:
+
+- Vercel Marketplace partners (Supabase is one): **inter-region bandwidth is free** when both use Vercel's network
+- Even if not: AWS/GCP intra-US data transfer is ~$0.02/GB — negligible for this traffic level
+
+**Verdict:** Bandwidth costs are essentially flat between the two approaches. The proposed approach sends larger originals from Supabase to Vercel on cache misses, but for this traffic level, the difference rounds to $0.
+
+---
+
+## 5. Cache Layering Analysis
+
+### Layer comparison
+
+| Layer | Current | Proposed |
+|-------|---------|----------|
+| Supabase Smart CDN | ✅ Caches transformed images (WebP 800×800) | ❌ Gone — only direct object URLs served |
+| Vercel Edge CDN | ✅ Caches re-optimized images | ✅ Same — caches optimized images |
+| Browser cache | ✅ Via `Cache-Control` | ✅ Same |
+| **Total cache layers** | **3** (Supabase CDN → Vercel → browser) | **2** (Vercel → browser) |
+
+### Real-world impact for this project
+
+- **Cold start (new image uploaded):** Current has Supabase Smart CDN caching the transformed version; proposed has nothing between Supabase origin and Vercel. But since the image was just uploaded, no one is requesting it yet. The first visitor triggers a cache fill at Vercel either way.
+- **Concurrent visitors (same hour):** Once Vercel edge has cached the optimized image, both approaches deliver identically (Vercel edge → browser). The missing Supabase CDN layer doesn't matter.
+- **Supabase Smart CDN TTL:** If Supabase CDN has a longer TTL than Vercel edge cache, the current approach could serve from Supabase CDN if Vercel's cache evicted. But Vercel's `minimumCacheTTL` (configurable to 7–31 days) makes this a non-issue.
+
+**Verdict:** The loss of the Supabase CDN cache layer is irrelevant for this project. Vercel's edge cache is the primary layer and handles all repeat traffic identically either way.
+
+---
+
+## 6. Hidden Costs
+
+### ✅ Vercel source image quota per cache-miss (confirmed)
+
+Each unique original URL × each requested width counts as a source image. Since the thumbnail and main image request different widths, each image burns ~2 source-image quota per cache-miss lifecycle. **This is the real cost risk.**
+
+**Mitigation:** Increase `minimumCacheTTL` in `next.config.ts`:
+```ts
+// next.config.ts
+images: {
+  minimumCacheTTL: 604800, // 7 days instead of default 3600
+  // ... existing remotePatterns
+}
+```
+With a 7-day TTL, the cache-miss lifecycle extends to a week — one cache fill per image per week regardless of visitors.
+
+### ✅ Admin image double-counting (already mitigated)
+
+The admin `BeneficiaryCard.tsx` already uses `unoptimized` on images — it does NOT consume Vercel image optimization quota. Only the public-facing sponsorship pages (SponsorshipCard, BeneficiaryDetails, SponsorshipModal) use `<Image>` without `unoptimized`, which is the intended behavior.
+
+### ✅ Same original requested at multiple sizes = multiple quota burns
+
+The `ProgressiveImage.tsx` requests the same original at two sizes (w=20 for thumbnail, default ~800 for main). **Vercel counts these as two source images** per cache lifecycle. This is the largest multiplier.
+
+**Mitigation:** If the thumbnail URL is constructed as `/_next/image?url=<direct-url>&w=20&q=20` as proposed, the `url` parameter is the same direct Supabase URL for both thumbnail and main image. But since `w` differs, they're different transformed outputs. According to Vercel docs: "any new transformation dimensions count as new source images." So yes, 2 counts per original.
+
+### ❌ Supabase storage egress surcharge (not a concern)
+
+Supabase's Pro plan includes generous egress. For this project's traffic, egress from serving originals to Vercel's edge is well within limits.
+
+### ❌ Vercel Functions duration increase (not a concern)
+
+The image optimization runs at the Vercel edge, not as a Serverless Function. No Functions duration cost is affected.
+
+### ❌ Multiple variants from `imageSizes` (not a concern)
+
+Next.js's `sizes` prop on `<Image>` controls which widths the browser requests. But Vercel only optimizes the widths actually requested. If the `sizes` attribute is set to `100vw` (as it is in ProgressiveImage), the browser typically requests one width per viewport. Most visitors will only trigger one width per image, not all configured widths.
+
+---
+
+## 7. Can We Stay on Vercel Hobby Plan?
+
+**Yes, with reasonable confidence — but there's a corner case.**
+
+### Baseline usage estimate
+
+| Scenario | Originals | × sizes | Monthly burn | Headroom (of 1,000) |
+|----------|-----------|---------|-------------|---------------------|
+| Current beneficiaries (50, 3 images avg) | 150 | 2 (thumb + main) | 300 | 700 — ✅ comfortable |
+| Future growth (100 beneficiaries, 5 images avg) | 500 | 2 | 1,000 | 0 — ⚠️ at limit |
+| Same, with 2 responsive sizes | 500 | 3 | 1,500 | -500 — ❌ over |
+
+### Risk factors for exceeding Hobby quota
+
+1. **Many beneficiaries per page load**: The sponsorship listing page fetches all images via `ImageCarousel`. If 50 cards load at once, each with 1 image → 50 originals in one page view → 100 source images (thumb + main) in a single pageload.
+2. **Multiple visitors before cache warms**: If 20 unique visitors hit the listing page before Vercel edge caches fill, you've burned 20×100 = 2,000 source images just from that page.
+3. **Images per beneficiary**: `BeneficiaryDetails` loads all images for one child. If a child has 5 images, that's 5 originals = 10 source images for one page view.
+
+### Mitigation strategy for staying on Hobby
+
+| Mitigation | Impact | Effort |
+|------------|--------|--------|
+| Set `minimumCacheTTL: 604800` | Extends cache to 7 days | Trivial (2 lines in `next.config.ts`) |
+| Only show thumbnail on detail page, not listing | Halves main/thumbnail duplications per card | Low (component prop change) |
+| Generate blurDataURL at upload time via edge function | Eliminates thumbnail as separate source image | Medium (new serverless function) |
+| Pin region to sfo1 (already done) | Ensures Supabase → Vercel latency is minimal | Already done |
+| Monitor via Vercel dashboard | Know when approaching limit | Free |
+
+**Bottom line:** For the current scale, Hobby works with `minimumCacheTTL` tuning. If you plan to scale to 100+ beneficiaries with 5+ images each, budget for Vercel Pro ($20/mo) — which is still $5/mo cheaper than Supabase Pro alone.
+
+---
+
+## 8. Monthly Cost Comparison Table
+
+### Scenario A: Current traffic (~50 beneficiaries, ~150 images)
+
+| Approach | Supabase | Vercel | Image Opt Cost | Total | Notes |
+|----------|----------|--------|---------------|-------|-------|
+| **Current (wasteful)** | Pro $25 | Hobby $0 | $0-ish (on top of plan) | **$25/mo** | Double-optimizing, paying for unneeded transforms |
+| **Proposed (Hobby)** | Free $0 | Hobby $0 | $0 (within 1k quota) | **$0/mo** | ✅ Best: saves $25/mo |
+| **Proposed (Pro)** | Free $0 | Pro $20 | Included in plan | **$20/mo** | ✅ Still cheaper than current by $5 |
+
+### Scenario B: Medium traffic (~100 beneficiaries, ~500 images)
+
+| Approach | Supabase | Vercel | Image Opt Cost | Total | Notes |
+|----------|----------|--------|---------------|-------|-------|
+| **Current (wasteful)** | Pro $25 | Hobby $0 | $0-ish | **$25/mo** | |
+| **Proposed (Hobby)** | Free $0 | Hobby $0 | $0 (within 1k quota if 2 sizes) | **$0/mo** | Margin of safety depends on cache hits |
+| **Proposed (Pro)** | Free $0 | Pro $20 | Included (5k quota) | **$20/mo** | ✅ Comfortable, saves $5/mo |
+
+### Scenario C: High traffic (~200 beneficiaries, 1,000+ images, many visitors)
+
+| Approach | Supabase | Vercel | Image Opt Cost | Total | Notes |
+|----------|----------|--------|---------------|-------|-------|
+| **Current (wasteful)** | Pro $25 | Pro $20 | $0-ish | **$45/mo** | Worst: paying both for transforms |
+| **Proposed (Pro)** | Free $0 | Pro $20 | $0–$5 (if over 5k) | **$20–$25/mo** | ✅ Cheaper by $20/mo |
+| **Proposed (Pro, tighten)** | Free $0 | Pro $20 | $0 | **$20/mo** | Increase `minimumCacheTTL` to stay under |
+
+> **Key insight:** The proposed approach is cheaper in **every** scenario because it eliminates either the Supabase Pro plan ($25/mo) or avoids double-paying both Vercel Pro ($20/mo) + Supabase Pro ($25/mo).
+
+---
+
+## 9. Additional Finding: `remotePatterns` Must Be Updated
+
+The current `next.config.ts`:
+
+```ts
+remotePatterns: [
+  { hostname: "*.supabase.co" },
+  // ...
+]
+```
+
+This allows `https://<project>.supabase.co/storage/v1/render/image/public/...` as source URLs (the current approach). After the change, source URLs will be `https://<project>.supabase.co/storage/v1/object/public/media/...`.
+
+The `*.supabase.co` glob covers both patterns, so **no config change is needed** for `remotePatterns` — it already allows the direct object URL path.
+
+But there's a `search` gotcha: the current config omits `search`, which means `?` is implicitly allowed. If `search` were set to `''` (empty string), the Supabase render URLs with query params would be rejected. The current config is fine.
+
+---
+
+## 10. Summary of Findings
+
+| Factor | Verdict |
+|--------|---------|
+| **Cost** | ✅ Always cheaper. Saves $5–$45/mo depending on plan tier. The minimum saving is $5/mo (downgrade Vercel Pro → Hobby, or drop Supabase Pro). |
+| **Latency (first visit)** | ⚠️ Marginally higher (~50ms) because Vercel must fetch and process larger originals. Imperceptible to users. |
+| **Latency (return visitors)** | ✅ Identical — Vercel edge cache serves either way. |
+| **Bandwidth costs** | ✅ Flat — negligible difference at this traffic level. |
+| **Cache layering** | ✅ Losing Supabase CDN layer is irrelevant. Vercel edge + browser cache handles everything. |
+| **Hidden cost: Vercel quota** | ⚠️ Need `minimumCacheTTL` tuning. Each image burns 2 source-image quota per cache lifecycle (thumb + main size). |
+| **Hobby viability** | ✅ Safe for current scale with tuning. Risky at 100+ beneficiaries / 5+ images each. |
+| **Worst case (cost increase)** | ❌ Not possible — this change saves money in every scenario. The only way to pay more is if you stay on Supabase Pro AND Vercel Pro. |
+| **Hidden benefit** | ✅ Eliminates current double-optimization waste. Currently both Supabase AND Vercel transform every image. |
+
+### Recommendation
+
+**Proceed with the change.** The architecture is simpler, eliminates double-optimization waste, and saves money at every traffic level. Tune `minimumCacheTTL` to 604800 (7 days) in `next.config.ts` as a one-line safeguard against Vercel quota burn.

--- a/review-risks.md
+++ b/review-risks.md
@@ -1,0 +1,237 @@
+# Risk Analysis: Replace Supabase Image Transforms with Next.js `<Image>`
+
+> Reviewed against codebase (2026-05-26) and [nextjs-image-transformation.md](./nextjs-image-transformation.md) plan, cross-referenced with [docs-findings.md](./docs-findings.md).
+
+---
+
+## 1. Rollback Complexity: LOW
+
+**Verdict:** Reverting is straightforward, but only after a full deploy rollback.
+
+**Evidence:**
+- All image URLs are constructed at render time (client or server), not persisted in the database. There is no column in `media` storing a transformed URL. The single exception is the `public_url` field returned in the **API response** from `POST /api/admin/beneficiaries/images/create` — but even that is consumed immediately by the upload handler and not stored long-term.
+- The `NEXT_PUBLIC_ENABLE_IMAGE_TRANSFORMS` flag is still fully functional in the current code. If the migration causes issues, you can re-enable the Supabase transform branch without reverting the entire codebase — just toggle the env var and delete the new `/_next/image` thumbnail code.
+- The API route (`images/create/route.ts`) returns a `public_url` in its JSON response. If this changes from Supabase-transform URL to direct URL, the upload handler on the admin page receives a different-shaped URL. Old stored responses won't break because nothing reads them after upload completes.
+- **Cached `/_next/image` URLs** from the new approach will 404 if you roll back to old code (since the `/_next/image` route won't recognize the old code's behavior). This is a transient visual issue — on rollback, all components re-render and regenerate Supabase URLs on the client, so the 404s are replaced within one render cycle. **Acceptable.**
+
+**Action:** If deploying, ship as a single atomic deploy, not as incremental changes. The old code path is cleanly separable by the feature flag, so a canary deploy of just the new code behind the flag would be safest.
+
+---
+
+## 2. Migration Sequencing: SHOULD BE TWO-PHASE
+
+**Verdict:** Do **not** go all-at-once. A canary-first sequence is easy and risk-free.
+
+**Recommended sequence:**
+
+```
+Phase 1 — Add Next.js config (no behavior change)
+├── Add `pathname: '/storage/v1/object/public/**'` to existing `*.supabase.co` remotePattern
+│   (currently the hostname wildcard is sufficient, but explicit pathname removes ambiguity)
+├── Deploy
+└── Verify: existing images still load. No regression.
+
+Phase 2 — Deploy the migration (flag-gated)
+├── In `media.ts`: new `buildStorageUrl` always returns direct URL
+├── In `imageTransform.ts`: `getTransformedImageUrl` returns direct URL
+├── In `generateThumbnailUrl`: new `/_next/image?w=...` construction
+├── Keep `NEXT_PUBLIC_ENABLE_IMAGE_TRANSFORMS=true` in production initially — but now it's a no-op
+├── Deploy and verify on dev (where flag was always false — same behavior)
+└── After 24h of monitoring: remove the flag from code and dotenv.sample
+```
+
+**Why this matters:** The flag path already works in dev (where transforms are disabled). Deploying Phase 2 with the flag still set in production means zero behavior change on day 1. You can then toggle the flag to `false` on a single staging instance to verify the new path works end-to-end before removing the flag entirely.
+
+---
+
+## 3. Thumbnail URL Construction (`/_next/image?url=...&w=20&q=20`): MEDIUM-HIGH RISK
+
+**This is the most dangerous assumption in the plan.** Let's unwind it.
+
+### Claim being made
+
+The plan says `generateThumbnailUrl` should return a URL like:
+
+```
+/_next/image?url=https%3A%2F%2F<project>.supabase.co%2Fstorage%2Fv1%2Fobject%2Fpublic%2Fmedia%2F...&w=20&q=20
+```
+
+and ProgressiveImage will render it as an `<Image>` with `unoptimized={true}` (because the URL starts with `/`).
+
+### Why this works in theory
+
+1. `/_next/image` is a valid API endpoint in Next.js (both dev and production on Vercel).
+2. It fetches the source URL, optimizes it to the requested width, and serves it back.
+3. `w=20` gets rounded to the closest configured `imageSizes` value — `16` — which Next.js will serve.
+4. Because `isThumbnailLocal` checks `thumbnailSrc?.startsWith('/')`, it returns `true`, so `unoptimized=true`, preventing the `<Image>` component from double-optimizing the already-optimized URL.
+
+### Why this is risky
+
+**Risk A — `imageSizes` rounding makes 20px → 16px, not 20px.** The default `imageSizes` array is `[16, 32, 48, 64, 96, 128, 256, 384]`. A requested width of 20 rounds to 16. The blur-up technique still works at 16px (it's small enough), but the actual request is for a different width than the code expresses. **Currently acceptable for blur-up but worth documenting.**
+
+**Risk B — The unoptimized logic is fragile.** ProgressiveImage's `unoptimized={isThumbnailLocal}` check only works because `/_next/image?...` starts with `/`. If the URL format ever changes (e.g., absolute URL with the deployment domain), the guard breaks and the `<Image>` component would try to re-optimize `/_next/image?url=/_next/image?...` — a double-nested URL that would almost certainly fail or behave unexpectedly. **This is not defensive code.**
+
+**Risk C — The thumbnail URL is constructed client-side but the `/_next/image` endpoint is server-side.** There is no client-side validation that the constructed URL is valid. If the source URL encoding has edge cases (unicode characters, special chars in the path), the `/_next/image` endpoint may reject the request with a 400. Supabase handles encoding internally; manual construction is error-prone.
+
+**Risk D — Vercel Image Optimization quota applies.** Even though the thumbnail is 16px at quality 20, each unique source image still counts against the Vercel plan's source image quota. The thumbnail and the full image are the same source URL being optimized to different sizes, so they count as two source images. **This is within expected behavior but should be budgeted.**
+
+### Safer alternative
+
+Instead of constructing `/_next/image` URLs manually, use Next.js's built-in `placeholder="blur"` + `blurDataURL` mechanism:
+
+```tsx
+// Generate a tiny base64 blur hash server-side (or at build time)
+// Plaiceholder is the recommended tool: https://plaiceholder.co
+import { getPlaiceholder } from "plaiceholder"
+
+const { base64 } = await getPlaiceholder(imageUrl)
+// Store base64 in the media table column, or compute at request time
+```
+
+This is the standard Next.js approach and avoids all the hand-rolled URL construction risks. It does require either:
+- Computing blur hashes at image upload time (store in DB)
+- Computing them at request time (server-side, cached)
+- Using an edge function
+
+**Recommendation:** Either use `placeholder="blur"` + `blurDataURL` (Server Components), or keep the current ProgressiveImage approach (client component) but construct the `/_next/image` URLs **server-side** in `generateThumbnailUrl` where encoding is handled more safely. Accept the 20→16px rounding but document it.
+
+---
+
+## 4. Cache Invalidation: LOW RISK
+
+**Verdict:** No conflict between old and new URLs. Separate URL spaces.
+
+**Evidence:**
+- Old URLs: `https://<project>.supabase.co/storage/v1/render/image/public/...?width=40&height=40&quality=20`
+- New URLs: `/_next/image?url=<encoded-supabase-url>&w=16&q=20`
+
+These are completely different origins and paths. No cache key collision possible.
+
+**Subtle cache consideration:** The Vercel CDN caches optimized images with a `minimumCacheTTL` (default 3600s). If an image changes on Supabase (same key, new content), the `/_next/image` cache will serve the old version for up to the TTL. This is **the same behavior as today** with Supabase's Smart CDN caching transformed images. No regression.
+
+**Action:** Consider increasing `images.minimumCacheTTL` in `next.config.ts` to match the expected update frequency of beneficiary photos (e.g., 1 day = 86400) to reduce optimization costs on Vercel.
+
+---
+
+## 5. The `blurDataURL` / SVG Placeholder Approach: ACCEPTABLE but COSTLY
+
+**Verdict:** Skipping `blurDataURL` and using the SVG placeholder is acceptable but degrades UX. The current ProgressiveImage approach (LQIP via tiny thumbnail + CSS blur) is already a solid middle ground.
+
+### How production apps handle this
+
+| Approach | Examples | Cost |
+|----------|----------|------|
+| `placeholder="blur"` with `blurDataURL` | Next.js docs, Vercel templates | Requires server-side blur hash generation |
+| LQIP (low-quality image placeholder) — tiny thumbnail + CSS blur | Medium, Pinterest, Airbnb | Two HTTP requests per image (cheap) |
+| Dominant color placeholder | Facebook, Google Images | Single color extraction, no HTTP overhead |
+| Generic SVG/icon placeholder | Default fallbacks, loading spinners | Simplest, worst UX |
+
+The current approach is standard **LQIP** — already used in production at scale. The plan proposes keeping this exact approach but swapping the thumbnail source from Supabase transform → `/_next/image`. This is perfectly acceptable.
+
+**The SVG placeholder exists as the fallback** (when thumbnail fails or is unavailable). It's not a replacement for the LQIP — it's the safety net. The plan correctly avoids touching `ProgressiveImage.tsx` and keeps the SVG fallback in place.
+
+**One concern:** The SVG placeholder (`/placeholder-person.svg`) is a generic silhouette. All beneficiary cards show the same shape before the image loads. This is already the current behavior. No regression.
+
+---
+
+## 6. Broken Image Detection (502/503 from Supabase): LOW-MEDIUM RISK
+
+**Verdict:** Graceful degradation exists, but the double-load pattern in `ProgressiveImage` adds complexity.
+
+### What happens on failure
+
+| Failure scenario | Current behavior | Post-migration behavior | Outcome |
+|---|---|---|---|
+| Supabase storage returns 502 | Image fails → fallback shows | Same | OK — fallback SVG shows |
+| Supabase storage is slow (>10s) | Image takes long to load | Same — plus `/_next/image` adds an extra hop | Worse latency for first uncached image |
+| Supabase is reachable but `/_next/image` fails | N/A | The `/_next/image` URL would return a 400/500. The `<Image>` for the thumbnail triggers `handleThumbnailError`, which sets `thumbnailError = true`, and `shouldShowImageImmediately = true`. The full image `<Image>` also tries to load via `/_next/image` URL (not manually constructed — the component constructs it) | Degraded but functional — no blur-up, but full image loads when available |
+| Supabase is down entirely | Both thumbnail and full image fail → fallback SVG | Same | OK |
+
+**Critical edge case — `/_next/image` upstream fetch failure:** If the source (Supabase) is reachable but the Vercel edge optimization crashes or times out for a specific image, the `/_next/image` URL returns a 500. The `<Image>` component fires `onError`, which sets `imageError = true`, and the fallback SVG placeholder shows. **This is acceptable** — the same behavior as a Supabase transform failure today.
+
+### Existing issue (not introduced by this plan)
+
+The `useEffect` in ProgressiveImage creates a **native `window.Image`** and sets `img.src = src`. This loads the raw Supabase URL directly (bypassing `/_next/image`). Meanwhile, the `<Image>` component renders with `src={displaySrc}` and goes through `/_next/image`. These are **two separate HTTP requests** for the same image. If one succeeds and the other fails before the handlers are nullified, the component state could briefly be inconsistent (one handler sets `imageLoaded`, the other sets `imageError`). The net result is transient — both handlers are idempotent — but it's wasted bandwidth.
+
+**Not blocking this migration.** The double-load pre-exists and is minor.
+
+---
+
+## 7. Race Conditions in ProgressiveImage: LOW RISK (pre-existing)
+
+**Verdict:** No new race conditions are introduced by this migration. Existing races are benign.
+
+### Existing races (all benign)
+
+**Race A — src change during load:**
+When the carousel changes images, the `useEffect` cleanup nullifies `img.onload` and `img.onerror`. A new effect runs with the new `src`. Between cleanup and the new effect, the old image might finish loading — but the handlers are already null, so nothing fires. This is correct.
+
+**Race B — useEffect handler vs Component onLoad handler:**
+The `useEffect` creates a native `window.Image` with anonymous handlers, and the `<Image>` component has `onLoad={handleImageLoad}` / `onError={handleImageError}`. Both `setImageLoaded(true)` calls are harmless duplicates. This is fine.
+
+**Race C — Thumbnail loads after full image:**
+When `thumbnailSrc` is present, the full image `<Image>` has `opacity: 0` until `imageLoaded`. If the full image loads before the thumbnail, it stays invisible until the thumbnail also loads (since `handleThumbnailLoad` doesn't gate the full image visibility — only `handleImageLoad` does). Actually wait — the full image visibility is only gated by `imageLoaded`, not by `thumbnailLoaded`. So the full image would fade in once it loads, regardless of thumbnail state. The thumbnail continues to show (but fades out via opacity transition). This is fine.
+
+### New concern (post-migration)
+
+**If thumbnail `/_next/image` URL construction fails** (bad encoding, unsupported format), the thumbnail receives a 400 from the `/_next/image` endpoint. The thumbnail `<Image>` fires `onError`, which calls `handleThumbnailError`. This sets `thumbnailError = true`, which makes `hasThumbnail = false`, which makes `shouldShowImageImmediately = true`. The full image then shows immediately (no blur-up). The user sees a flash from SVG placeholder to full image. **Acceptable degradation.**
+
+---
+
+## 8. Missed Supabase Image Endpoint References: NO NEW FINDINGS
+
+**Verdict:** The `grep` for `render/image` returned zero matches in `src/`. All current transform URLs are generated through the Supabase JS SDK (`getPublicUrl` with `transform` option), not by manually constructing `render/image` URLs.
+
+### All touchpoints of the transform code
+
+| File | Current approach | What changes |
+|---|---|---|
+| `src/utils/supabase/media.ts` | `buildStorageUrl` uses SDK transform branch | Remove transform branch entirely, always return direct URL |
+| `src/utils/supabase/imageTransform.ts` | `getTransformedImageUrl` uses SDK transform branch | Remove transform logic, return direct URL |
+| `src/app/api/admin/beneficiaries/images/create/route.ts` | Calls `getTransformedImageUrl` for response `public_url` | After change, same function returns direct URL → response changes shape |
+| `src/utils/email.ts` | Calls `generatePublicUrl` (which uses transform) | After change, email gets full-resolution original instead of 800x800 WebP |
+
+**Email risk (minor but real):** The email template uses `<img>` tags (not Next.js `<Image>`), so it never used `/_next/image`. After migration, `generatePublicUrl` returns the full-resolution original image instead of a transformed 800x800 WebP version. Email clients download the full file, which could be:
+- Slower to load in the email
+- Rejected by some email clients with file size limits (Gmail: ~25MB, Outlook: ~10MB)
+
+**Recommendation:** In the email utility, either:
+1. Continue to use a resize query (e.g., `buildStorageUrl(key, { width: 800 })` but always use the direct URL path — this is no longer a Supabase Pro feature, it's just... wait, no, direct URLs don't support query params for resizing.
+2. Upload a properly sized version for email use.
+3. Accept that email images will load at full resolution (most beneficiary photos are <500KB JPEGs — acceptable).
+
+**This is a real but minor migration gap the plan didn't mention.**
+
+### Dead code check
+
+| Function | Used elsewhere? | Safe to remove? |
+|---|---|---|
+| `getImageVariants` | Not imported anywhere in `src/` | ✅ Yes |
+| `getSignedTransformedUrl` | Not imported anywhere in `src/` | ✅ Yes |
+| `uploadImageForTransformation` | Only called within `imageTransform.ts` itself (`uploadImagesForTransformation`) | ✅ Yes (if both removed) |
+| `uploadImagesForTransformation` | Not imported anywhere in `src/` | ✅ Yes |
+| `deleteTransformedImages` | Not imported anywhere in `src/` | ✅ Yes |
+
+---
+
+## Summary of Blockers
+
+| # | Risk | Severity | Mitigation |
+|---|------|----------|------------|
+| 1 | Manual `/_next/image` URL construction with unvalidated encoding | **High** | Use URL constructor (`new URL()`) or server-side encoding. Verify Supabase object key encoding edge cases. |
+| 2 | Email gets full-res images instead of 800x800 WebP | **Medium** | Evaluate email image sizes. Add explicit sizing if needed. |
+| 3 | Thumbnail width 20 → rounds to 16px | **Low** | Document the rounding. Accept for blur-up. Or add `16` explicitly in the thumbnail URL. |
+| 4 | Vercel Image Optimization quota from thumbnail + full image | **Low** | Ensure budget accounts for ~2x source images (1 thumbnail + 1 full). Use `minimumCacheTTL` to reduce re-optimizations. |
+| 5 | `isThumbnailLocal` / `unoptimized` guard is fragile | **Medium** | Add an explicit `unoptimized={true}` prop to the thumbnail `<Image>` in ProgressiveImage instead of relying on the `startsWith('/')` heuristic. This is defensive regardless of migration. |
+| 6 | `public_url` in upload API response changes format | **Low** | Confirm the admin upload handler doesn't persist or rely on the URL format. It uses it for immediate display only. |
+
+## Friday-Deployment Checklist
+
+- [ ] `remotePatterns` in `next.config.ts` — confirm `*.supabase.co` covers `/storage/v1/object/public/**` (it does with the wildcard, but add explicit pathname for clarity)
+- [ ] Test that `/_next/image` actually serves a 20px-requested image (verify it rounds to 16px, and that 16px is acceptable for blur-up)
+- [ ] Test one email after migration to verify image loads in Gmail/Outlook within acceptable size limits
+- [ ] Set `NEXT_PUBLIC_ENABLE_IMAGE_TRANSFORMS=false` in dev and staging before production — simulate the full migration path
+- [ ] Verify the admin image upload flow returns usable `public_url` values
+- [ ] Verify dotenv.sample is updated (remove deprecated flag)
+- [ ] Add `16` to the thumbnail URL explicitly (`w=16`) since that's what it rounds to anyway — be honest about what's being requested
+- [ ] Verify thumbnail `<Image>` doesn't double-optimize: check the actual rendered HTML in dev tools

--- a/review-technical.md
+++ b/review-technical.md
@@ -1,0 +1,161 @@
+# Technical Feasibility Review: Replace Supabase Transforms with Next.js Image Optimization
+
+**Plan:** `nextjs-image-transformation.md`
+**Reference:** `docs-findings.md`
+**Date:** 2026-05-26
+
+---
+
+## Findings
+
+### 1. ✅ Can `/_next/image` URLs be constructed manually for a 20px thumbnail?
+
+**Yes.** The `/_next/image` endpoint is a standalone HTTP API — it is *not* exclusive to the `<Image>` component. The docs confirm the URL format:
+
+> `/_next/image?url=<encoded-source-url>&w=<width>&q=<quality>` — docs-findings.md:87
+
+The two guards are:
+1. The source URL's hostname must be in `remotePatterns` — ✅ already present (`*.supabase.co`)
+2. The `w` parameter should match a configured size (it's rounded to nearest) — see Finding 2
+
+**How it flows through ProgressiveImage:**
+- `generateThumbnailUrl` returns `/_next/image?w=16&q=20&url=<encoded-direct-url>`
+- This is a local path (starts with `/`) → `isThumbnailLocal` = `true` → `unoptimized` = `true` (ProgressiveImage.tsx:139)
+- The `<Image>` renders `<img src="/_next/image?w=16&q=20&url=..." />` directly
+- The browser fetches `/_next/image?w=16&q=20&url=...` from the Next.js server
+- The server validates against `remotePatterns`, fetches from Supabase, resizes to 16px at quality 20, returns it
+
+This works end-to-end. The `unoptimized={true}` on the `<Image>` component is correct here — it prevents the component from double-wrapping the already-optimized URL.
+
+### 2. 🔴 BUG IN PLAN: `w=20` rounds down to `16`px — plan says `20`
+
+The plan proposes `w=20&q=20` for the blur thumbnail. The docs state:
+
+> The `<w>` parameter is one of the configured `deviceSizes` or `imageSizes` widths (rounded to nearest match). — docs-findings.md:88
+
+The default `imageSizes` are `[16, 32, 48, 64, 96, 128, 256, 384]` (docs-findings.md:120). `20` rounds to `16` (nearest match), not `20`. The plan should use `w=16` for clarity and predictability.
+
+**Impact:** Negligible in practice (it's a blur placeholder), but the plan makes an incorrect claim about the exact width. Fix: change `w=20` to `w=16` in the proposal.
+
+### 3. ✅ `remotePatterns` works for direct Supabase storage URLs — no `search: ''` gotcha
+
+The docs highlight a gotcha:
+
+> If `search` is set to `''` (empty string), **no query parameters are allowed** on the source URL. Omit `search` or set it to `'?'` to allow any query params. — docs-findings.md:133
+
+**The current config omits `search` entirely** (next.config.ts:39-50), so query parameters ARE allowed on source URLs. The direct storage URL `https://<project>.supabase.co/storage/v1/object/public/media/...` has no query params anyway, so even if `search: ''` were set, it would still match.
+
+The existing `hostname: "*.supabase.co"` pattern (next.config.ts:49) matches `https://<project-id>.supabase.co/storage/v1/object/public/...` with no restrictions. ✅
+
+### 4. ✅ Vercel dimension/image size limits are well within bounds
+
+Docs reference:
+
+> Source image max dimensions: 8192 × 8192 px — docs-findings.md:159
+> Optimized image size limit: 10 MB — docs-findings.md:160
+
+Beneficiary profile photos are typically < 5 MB and < 4000px on the longest side. No risk of hitting these limits for any images in the codebase.
+
+### 5. ✅ `getSignedTransformedUrl` removal is safe — zero callers
+
+**Codebase search:** The only matches for `getSignedTransformedUrl` are in `nextjs-image-transformation.md` (the plan) and the definition in `imageTransform.ts:166`. No file anywhere imports or calls this function. Zero callers. ✅ Safe to remove.
+
+### 6. ✅ `getImageVariants` removal is safe — zero callers
+
+**Codebase search:** The only matches are the plan and the definition in `imageTransform.ts:71`. Not imported elsewhere. ✅ Safe to remove.
+
+### 7. ✅ CORS is a non-issue — server-to-server requests
+
+The `/_next/image` endpoint fetches source images server-side (Next.js server → Supabase origin). This is a server-to-server request, not subject to browser CORS. Supabase public buckets accept all requests with no referrer restrictions.
+
+> The docs confirm: "Direct Supabase URLs used as `/_next/image` source URLs must be fetchable by the Next.js server. Since the storage bucket is public and Supabase doesn't restrict fetching by referrer, this should work" — docs-findings.md:178-179
+
+### 8. 🔴 `getTransformedImageUrl` IS used — plan missed this caller
+
+The plan says to "Remove transform logic, return direct URL always" for `getTransformedImageUrl` but doesn't mention that it's **actively used** in the admin upload API route:
+
+**`src/app/api/admin/beneficiaries/images/create/route.ts:82`**:
+```ts
+public_url: getTransformedImageUrl('media', `${beneficiaryId}/IMAGE/${mediaRow.id}.${extension}`, {
+  width: 800,
+  height: 800,
+  quality: 90,
+  resize: 'cover'
+}),
+```
+
+After the change, this would return a direct object URL instead of a transformed URL. The endpoint returns the URL to the admin UI after upload. Functionally this works (the admin sees the untransformed image), but it's a behavioral change not called out in the plan. The plan should:
+- Document this impact explicitly
+- Consider whether the response should instead use `generatePublicUrl` (which already handles images with appropriate sizing params)
+
+### 9. 🔴 COST OMISSION: "Free (Vercel edge, included in plan)" is misleading
+
+The plan says "Cost | Pro plan required → Free (Vercel edge, included in plan)." This is inaccurate. Vercel Image Optimization has real quotas and costs:
+
+| Plan | Included Source Images | Overage |
+|------|----------------------|---------|
+| Hobby (Free) | 1,000 source images/mo | Pay-as-you-go |
+| Pro ($20/mo) | 5,000 source images/mo | $5 per 1,000 additional |
+
+— docs-findings.md:168-174
+
+**Each unique source image URL optimized by `/_next/image` counts against this quota once per cache-miss lifecycle.** This means:
+- Each beneficiary photo = 1 source image
+- Each thumbnail (`/_next/image?w=16&q=20&url=<same>`) = a **separate** optimization (different `w`/`q` params), so each photo generates **2 source image counts** (full-size + thumbnail)
+- If the codebase has hundreds of beneficiary photos with multiple display sizes, the quota burns proportionally
+
+The plan should acknowledge the actual cost structure, including that thumbnail generation doubles per-image optimization costs.
+
+### 10. 🔴 PLANNING GAP: No `next.config.ts` changes mentioned for default `imageSizes` or `minimumCacheTTL`
+
+The plan says "next.config.ts (if any image optimization config is needed)" without specifying what. Two recommendations the plan misses:
+
+**a) Add `w=16` to `imageSizes` explicitly** — While 16 is already in the default set (docs-findings.md:120), being explicit makes the configuration self-documenting and prevents future confusion about which sizes are used.
+
+**b) Consider `minimumCacheTTL`** — Default is 3600s (1 hour) on Vercel (docs-findings.md:157). For static beneficiary photos that never change, increasing this to 31 days (`2678400`) would reduce optimization costs significantly by extending cache lifetime. Not required, but a notable cost-saving opportunity the plan doesn't mention.
+
+### 11. 🔴 DEV MODE LIMITATION NOT CALLED OUT
+
+The plan doesn't mention that in `next dev`, `/_next/image` does NOT actually transform images:
+
+> "In `next dev`, your images will not be optimized. Images are optimized during the production build (`next build && next start`) or on Vercel." — docs-findings.md (Next.js docs, paraphrased)
+
+In dev mode, `/_next/image?w=16&q=20&url=<big-image>` returns the original full-resolution image. The CSS blur (`filter: blur(10px)`) still applies, so the placeholder is a blurred full-resolution image — functionally correct but wasteful of bandwidth. This is cosmetic (not a blocker), but should be documented so developers understand why the blur placeholder doesn't shrink during local development.
+
+### 12. ✅ ProgressiveImage already handles `/_next/image` URLs correctly
+
+Confirmed: The `isThumbnailLocal` check (`thumbnailSrc?.startsWith('/')`) correctly identifies `/_next/image?w=...` as local. The `unoptimized={isThumbnailLocal}` passes the URL through as a raw `<img>` tag. The `/_next/image` endpoint on the server processes it. No code changes needed in `ProgressiveImage.tsx`. ✅
+
+---
+
+## Summary
+
+| Claim | Verdict | Details |
+|-------|---------|---------|
+| `/_next/image` URLs work standalone | ✅ Yes | Server-side endpoint, not component-exclusive |
+| Width rounding issue | 🔴 Fix: `w=20` → `w=16` | Rounds to nearest configured `imageSizes` (16) |
+| `search: ''` gotcha | ✅ Not an issue | Current config omits `search`, so query params allowed |
+| Vercel limits | ✅ Fine | 8192px / 10MB far above any usage |
+| `getSignedTransformedUrl` removal | ✅ Safe | Zero callers |
+| `getImageVariants` removal | ✅ Safe | Zero callers |
+| CORS with Supabase | ✅ Non-issue | Server-to-server fetch, not browser |
+| `getTransformedImageUrl` usage | 🔴 Plan missed | Active caller in admin upload route (line 82) |
+| Cost claim | 🔴 Misleading | Not free — has quotas & overage ($5/1K) |
+| `next.config.ts` changes | 🔴 Under-specified | No mention of `minimumCacheTTL` or explicit `imageSizes` |
+| Dev mode behavior | 🔴 Not called out | `/_next/image` doesn't resize in `next dev` |
+
+### Blockers
+
+None. The plan is feasible. All issues are explanatory gaps or minor corrections.
+
+### Required fixes before proceeding
+
+1. **Plan: change `w=20` to `w=16`** for the thumbnail URL (or add 20 to `imageSizes`)
+2. **Plan: document the active `getTransformedImageUrl` caller** in admin upload route (the function still works, it just returns a different URL format — this is a behavior change, not a breakage)
+3. **Plan: correct "Free (Vercel edge)" to reflect actual pricing** (included quota, not free; thumbnails double per-image counts)
+
+### Recommended additions to the plan
+
+4. Add `imageSizes: [16, 32, 48, 64, 96, 128, 256, 384]` explicitly in `next.config.ts` for documentation
+5. Consider adding `minimumCacheTTL: 2678400` (31 days) for static beneficiary photos to reduce optimization costs
+6. Add a note that `/_next/image` doesn't resize in `next dev` mode (CSS-blur still works but uses full-resolution image)

--- a/src/components/common/ProgressiveImage.tsx
+++ b/src/components/common/ProgressiveImage.tsx
@@ -136,7 +136,6 @@ export const ProgressiveImage: React.FC<ProgressiveImageProps> = ({
 
   // Check if src is a local path (starts with /) or external URL
   const isLocalImage = displaySrc.startsWith('/')
-  const isThumbnailLocal = thumbnailSrc?.startsWith('/')
 
   return (
     <Box
@@ -205,7 +204,7 @@ export const ProgressiveImage: React.FC<ProgressiveImageProps> = ({
               sizes={sizes || "100vw"}
               onLoad={handleThumbnailLoad}
               onError={handleThumbnailError}
-              unoptimized={isThumbnailLocal}
+              unoptimized={true}
               style={{ objectPosition: "center 5%" }}
               priority
             />
@@ -218,7 +217,7 @@ export const ProgressiveImage: React.FC<ProgressiveImageProps> = ({
               className="object-cover"
               onLoad={handleThumbnailLoad}
               onError={handleThumbnailError}
-              unoptimized={isThumbnailLocal}
+              unoptimized={true}
               style={{ objectPosition: "center 5%" }}
               priority
             />

--- a/src/utils/email.ts
+++ b/src/utils/email.ts
@@ -145,7 +145,7 @@ async function getBeneficiaryImageUrl(beneficiaryId: string): Promise<string | n
     
     // Try to generate public URL using the media utility
     try {
-      const publicUrl = generatePublicUrl(firstImage)
+      const publicUrl = generatePublicUrl(firstImage, { forceTransform: true })
       return publicUrl
     } catch (urlError) {
       console.error(`[Email] Failed to generate public URL for beneficiary ${beneficiaryId}:`, urlError)

--- a/src/utils/supabase/imageTransform.ts
+++ b/src/utils/supabase/imageTransform.ts
@@ -1,13 +1,12 @@
 /**
- * Supabase Image Transformation Utilities
- * 
- * This module provides utilities for using Supabase's built-in image transformation API
- * as documented at: https://supabase.com/docs/guides/storage/serving/image-transformations
+ * Supabase Storage URL Utilities
+ *
+ * Generates direct storage URLs. Image optimization is handled by
+ * Next.js <Image> and /_next/image — no Supabase transforms are used.
+ *
+ * For cases where Supabase transforms are needed (e.g. email rendering
+ * without Next.js), use media.ts's generatePublicUrl with { forceTransform: true }.
  */
-
-import { createClient } from "@/utils/supabase/client"
-
-const supabase = createClient()
 
 export interface ImageTransformOptions {
   width?: number
@@ -18,176 +17,18 @@ export interface ImageTransformOptions {
 }
 
 /**
- * Generate a transformed image URL using Supabase Image Transformation API
- * 
- * @param bucket - The storage bucket name
- * @param path - The path to the image in the bucket
- * @param options - Transformation options
- * @returns The transformed image URL
- * 
- * @example
- * ```typescript
- * const thumbnailUrl = getTransformedImageUrl('media', 'images/photo.jpg', {
- *   width: 300,
- *   height: 300,
- *   quality: 80,
- *   resize: 'contain'
- * })
- * ```
+ * Generate a direct storage URL for a given bucket + path.
+ * Used by the admin image upload route for immediate display in responses.
+ * Image optimization is handled by the consuming Next.js <Image> component.
  */
 export const getTransformedImageUrl = (
   bucket: string,
   path: string,
-  options: ImageTransformOptions = {}
+  _options?: ImageTransformOptions,
 ): string => {
-  const transformOptions: {
-    width: number;
-    height: number;
-    quality: number;
-    resize?: 'cover' | 'contain' | 'fill';
-    format?: 'origin';
-  } = {
-    width: options.width || 400,
-    height: options.height || 400,
-    quality: options.quality || 80,
+  const base = process.env.NEXT_PUBLIC_SUPABASE_URL?.replace(/\/$/, "")
+  if (!base) {
+    throw new Error("Environment variable NEXT_PUBLIC_SUPABASE_URL is not set")
   }
-  
-  if (options.resize) {
-    transformOptions.resize = options.resize
-  }
-  
-  if (options.format) {
-    transformOptions.format = options.format
-  }
-
-  const { data } = supabase.storage
-    .from(bucket)
-    .getPublicUrl(path, {
-      transform: transformOptions
-    })
-
-  return data.publicUrl
-}
-
-/**
- * Generate multiple transformed image URLs for different use cases
- */
-export const getImageVariants = (bucket: string, path: string) => ({
-  thumbnail: getTransformedImageUrl(bucket, path, {
-    width: 150,
-    height: 150,
-    quality: 70
-  }),
-  small: getTransformedImageUrl(bucket, path, {
-    width: 300,
-    height: 300,
-    quality: 80
-  }),
-  medium: getTransformedImageUrl(bucket, path, {
-    width: 600,
-    height: 600,
-    quality: 85
-  }),
-  large: getTransformedImageUrl(bucket, path, {
-    width: 1200,
-    height: 1200,
-    quality: 90
-  }),
-  original: getTransformedImageUrl(bucket, path, {
-    format: 'origin' // Keep original format
-  })
-})
-
-/**
- * Upload an image to Supabase storage for transformation
- * 
- * @param bucket - The storage bucket name
- * @param path - The path where to store the image
- * @param file - The image file to upload
- * @returns The uploaded file path
- */
-export const uploadImageForTransformation = async (
-  bucket: string,
-  path: string,
-  file: File
-): Promise<string> => {
-  
-  const { error } = await supabase.storage
-    .from(bucket)
-    .upload(path, file, {
-      cacheControl: '3600',
-      upsert: true,
-      contentType: file.type
-    })
-
-  if (error) {
-    console.error('Upload error:', error)
-    throw new Error(`Failed to upload image: ${error.message}`)
-  }
-
-  return path
-}
-
-/**
- * Batch upload multiple images for transformation
- */
-export const uploadImagesForTransformation = async (
-  bucket: string,
-  files: File[],
-  basePath: string = 'temp'
-): Promise<string[]> => {
-  const uploadPromises = files.map(async (file, index) => {
-    const fileExt = file.name.split('.').pop()
-    const fileName = `${Date.now()}-${index}-${Math.random().toString(36).substring(2)}.${fileExt}`
-    const filePath = `${basePath}/${fileName}`
-    
-    return uploadImageForTransformation(bucket, filePath, file)
-  })
-
-  return Promise.all(uploadPromises)
-}
-
-
-/**
- * Delete images from Supabase storage
- */
-export const deleteTransformedImages = async (
-  bucket: string,
-  paths: string[]
-): Promise<void> => {
-  const { error } = await supabase.storage
-    .from(bucket)
-    .remove(paths)
-
-  if (error) {
-    throw new Error(`Failed to delete images: ${error.message}`)
-  }
-}
-
-/**
- * Get a signed URL for a transformed image (for private buckets)
- */
-export const getSignedTransformedUrl = async (
-  bucket: string,
-  path: string,
-  expiresIn: number = 3600,
-  options: ImageTransformOptions = {}
-): Promise<string> => {
-  const { data, error } = await supabase.storage
-    .from(bucket)
-    .createSignedUrl(path, expiresIn, {
-      transform: {
-        width: options.width || 400,
-        height: options.height || 400,
-        quality: options.quality || 80,
-        // Note: Supabase automatically optimizes to WebP when supported
-        ...(options.format && { format: options.format })
-      }
-    })
-
-  if (error) {
-    throw new Error(`Failed to create signed URL: ${error.message}`)
-  }
-
-  return data.signedUrl
+  return `${base}/storage/v1/object/public/${bucket}/${encodeURI(path)}`
 }

--- a/src/utils/supabase/media.ts
+++ b/src/utils/supabase/media.ts
@@ -46,23 +46,62 @@ export const getStorageKey = (media: MediaRow): string => {
   return `${normalizedParentId}/${normalizedType}/${normalizedId}.${normalizedExt}`
 }
 
+/* ---- Shared internal helpers ---- */
+
+export interface ImageTransformOptions {
+  width?: number
+  height?: number
+  quality?: number
+  resize?: 'cover' | 'contain' | 'fill'
+  format?: 'origin'
+}
+
 /**
- * Generate the public URL for a given media row.
- * For images, uses Supabase's image transformation API to ensure WebP format and proper sizing.
- * For videos, returns the direct public URL.
+ * Build a direct storage URL for a given key.
+ * Always returns the /storage/v1/object/public/ path (no Supabase transforms).
  */
-export const generatePublicUrl = (media: MediaRow): string => {
-  const base = process.env.NEXT_PUBLIC_SUPABASE_URL
+function buildStorageUrl(key: string): string {
+  const base = process.env.NEXT_PUBLIC_SUPABASE_URL?.replace(/\/$/, "")
   if (!base) {
     throw new Error("Environment variable NEXT_PUBLIC_SUPABASE_URL is not set")
   }
+  return `${base}/storage/v1/object/public/${STORAGE_BUCKET}/${encodeURI(key)}`
+}
 
+/* ---- Public API ---- */
+
+export interface GeneratePublicUrlOptions {
+  /**
+   * When true, generates a Supabase-transformed URL instead of a direct storage URL.
+   * Used only for email rendering (email clients don't go through Next.js <Image>).
+   * Requires Supabase Pro plan for the /render/image/ endpoint.
+   */
+  forceTransform?: boolean
+}
+
+/**
+ * Generate a public URL for a given media row.
+ *
+ * By default returns a direct /storage/v1/object/public/ URL which relies on
+ * Next.js <Image> optimization for resizing and format conversion.
+ *
+ * Pass { forceTransform: true } when the URL will be used outside of Next.js
+ * rendering (e.g. email <img> tags), to get a Supabase-transformed WebP URL.
+ *
+ * For videos and other media types, always returns the direct public URL.
+ */
+export const generatePublicUrl = (
+  media: MediaRow,
+  options?: GeneratePublicUrlOptions,
+): string => {
   const key = getStorageKey(media)
-  const supabase = createClient()
 
-  if (media.type === "IMAGE") {
-    // Use Supabase's built-in image transformation API
-    const { data } = supabase.storage
+  if (
+    media.type === "IMAGE" &&
+    options?.forceTransform
+  ) {
+    // Supabase transform — used by email where <Image> optimization isn't available
+    const { data } = createClient().storage
       .from(STORAGE_BUCKET)
       .getPublicUrl(key, {
         transform: {
@@ -72,53 +111,29 @@ export const generatePublicUrl = (media: MediaRow): string => {
           resize: "cover",
         },
       })
-
     return data.publicUrl
   }
 
-  // For videos and other media types, return the direct public URL
-  const normalizedBase = base.replace(/\/$/, "")
-  return `${normalizedBase}/storage/v1/object/public/${STORAGE_BUCKET}/${encodeURI(key)}`
+  return buildStorageUrl(key)
 }
 
 /**
- * Generate a thumbnail URL for progressive image loading.
- * Creates a small, low-quality version for blur-up placeholder effect.
- * Falls back to the regular image URL if transformation fails.
+ * Generate a thumbnail URL for progressive image loading (blur-up effect).
+ * Returns a Next.js /_next/image URL optimized to 16px at low quality.
+ * The caller should render this via <Image unoptimized={true}> with CSS blur.
+ * Returns undefined when the URL cannot be constructed.
  */
 export const generateThumbnailUrl = (media: MediaRow): string | undefined => {
-  const base = process.env.NEXT_PUBLIC_SUPABASE_URL
-  if (!base) {
+  if (media.type !== "IMAGE") return undefined
+
+  try {
+    const directUrl = buildStorageUrl(getStorageKey(media))
+    const encodedUrl = encodeURIComponent(directUrl)
+    return `/_next/image?url=${encodedUrl}&w=16&q=20`
+  } catch (error) {
+    console.warn("Failed to generate thumbnail URL:", error)
     return undefined
   }
-
-  const key = getStorageKey(media)
-  const supabase = createClient()
-
-  if (media.type === "IMAGE") {
-    try {
-      // Generate a small, low-quality thumbnail for progressive loading
-      // Supabase's transform API uses /render/image/ endpoint - this is correct!
-      const { data } = supabase.storage
-        .from(STORAGE_BUCKET)
-        .getPublicUrl(key, {
-          transform: {
-            width: 40,
-            height: 40,
-            quality: 20,
-            resize: "cover",
-          },
-        })
-
-      return data.publicUrl
-    } catch (error) {
-      console.warn('Failed to generate thumbnail URL:', error)
-      return undefined
-    }
-  }
-
-  // For videos and other media types, don't generate thumbnails
-  return undefined
 }
 
 /**


### PR DESCRIPTION
Drafted changes to strip supabase image transformations in favor of nextjs. Pending testing and verification.

…js /_next/image

Removes Supabase Image Transformation (/render/image/) from the main rendering pipeline. Images now serve as direct /storage/v1/object/public/ URLs and rely on Next.js <Image> optimization (/_next/image) for resizing, WebP conversion, and quality control.

Changes:
- buildStorageUrl: stripped transform branch, always returns direct URL
- generatePublicUrl: added { forceTransform: true } option (email only)
- generateThumbnailUrl: returns /_next/image?w=16&q=20 URLs instead of Supabase-transform URLs; works on both dev and prod
- imageTransform.ts: stripped transform logic, removed 5 unused exports
- email.ts: passes forceTransform:true to keep Supabase transforms for email rendering (no Next.js <Image> available in email clients)
- ProgressiveImage.tsx: hardcoded thumbnail unoptimized={true}
- next.config.ts: added minimumCacheTTL: 604800 (7 days)
- dotenv.sample: removed NEXT_PUBLIC_ENABLE_IMAGE_TRANSFORMS flag

UNTESTED — this branch needs verification before merge.