### PR TITLE
Fix Vercel build and clean portal envs

### DIFF
--- a/dotenv.sample
+++ b/dotenv.sample
@@ -7,12 +7,9 @@ NEXT_PUBLIC_MAPTILER_KEY=
 NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=
 STRIPE_SECRET_KEY=
 STRIPE_WEBHOOK_SECRET=
-# Legacy single-account server fallback for email portal links.
-# Prefer NEXT_PUBLIC_STRIPE_PORTAL_URL_US/UK for new deployments.
-STRIPE_PORTAL_URL=
 NEXT_PUBLIC_BASE_URL=https://localhost:3000/
 
-# Multi-region Stripe (optional — leave commented out to run single-account).
+# Multi-region Stripe (optional, leave commented out to run single-account).
 # When enabled, each region has its own Stripe account/dashboard; new
 # subscriptions and partnerships are stamped with `payment_region` so
 # cancel/refund/portal/email flows route to the correct account.
@@ -23,7 +20,7 @@ NEXT_PUBLIC_BASE_URL=https://localhost:3000/
 # paths and must stay "us" for this deployment. A value outside the supported
 # set ("us" | "uk") throws on boot rather than crashing the first request.
 # The legacy unsuffixed vars above act as fallbacks for the default region
-# during migration to per-region keys, but they do not configure both accounts.
+# during migration to per-region keys. They do not configure both accounts.
 #
 # STRIPE_DEFAULT_REGION=us
 # STRIPE_SECRET_KEY_US=
@@ -39,21 +36,21 @@ NEXT_PUBLIC_BASE_URL=https://localhost:3000/
 # "Manage Subscription" links and server-rendered email template links.
 # These URLs are not secrets, so use the same NEXT_PUBLIC values for both
 # browser and server surfaces. If you configure only one region during
-# rollout, the other region still renders a working link using the legacy
-# https://stripe.creatorshare.com fallback rather than dropping out.
+# rollout, the other region still renders the shared fallback URL rather
+# than dropping out.
 #
 # Webhook endpoints:
-#   /api/webhooks/stripe/{region}  -- preferred, validates against the
+#   /api/webhooks/stripe/{region}     preferred, validates against the
 #                                     STRIPE_WEBHOOK_SECRET_<REGION> for the
 #                                     account that sent the event.
-#   /api/webhooks/stripe           -- legacy back-compat shim that delegates
+#   /api/webhooks/stripe              legacy back-compat shim that delegates
 #                                     to STRIPE_DEFAULT_REGION. Stripe
 #                                     dashboards pointed here for a non-
 #                                     default account will fail signature
 #                                     verification; migrate them to the
 #                                     per-region URL once both regions ship.
 
-# DEPRECATED — Global sponsorship amount override (dollars in cents integer string).
+# DEPRECATED, Global sponsorship amount override (dollars in cents integer string).
 # Superseded by per-type vars below (NEXT_PUBLIC_SPONSORSHIP_AMOUNT_*).
 # Leave empty unless you need a single hardcoded amount for all types.
 NEXT_PUBLIC_SPONSORSHIP_GOAL=

--- a/dotenv.sample
+++ b/dotenv.sample
@@ -4,40 +4,33 @@ NEXT_SERVICE_ROLE_KEY=
 NEXT_PUBLIC_SUPABASE_STORAGE_BUCKET=
 NEXT_PUBLIC_MAPBOX_TOKEN=
 NEXT_PUBLIC_MAPTILER_KEY=
-NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=
-STRIPE_SECRET_KEY=
-STRIPE_WEBHOOK_SECRET=
 NEXT_PUBLIC_BASE_URL=https://localhost:3000/
 
-# Multi-region Stripe (optional, leave commented out to run single-account).
+# Stripe accounts
 # When enabled, each region has its own Stripe account/dashboard; new
 # subscriptions and partnerships are stamped with `payment_region` so
 # cancel/refund/portal/email flows route to the correct account.
 #
 # Sponsor checkout routes Stripe accounts from selected payment currency:
 # USD goes to the US account, while AUD, GBP, and EUR go to the UK account.
-# STRIPE_DEFAULT_REGION remains the legacy fallback region for non-currency
-# paths and must stay "us" for this deployment. A value outside the supported
-# set ("us" | "uk") throws on boot rather than crashing the first request.
-# The legacy unsuffixed vars above act as fallbacks for the default region
-# during migration to per-region keys. They do not configure both accounts.
+# STRIPE_DEFAULT_REGION is the fallback selector for non-currency paths and
+# must stay "us" for this deployment. A value outside the supported set
+# ("us" | "uk") throws on boot rather than crashing the first request.
 #
-# STRIPE_DEFAULT_REGION=us
-# STRIPE_SECRET_KEY_US=
-# NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY_US=
-# STRIPE_WEBHOOK_SECRET_US=
-# NEXT_PUBLIC_STRIPE_PORTAL_URL_US=
-# STRIPE_SECRET_KEY_UK=
-# NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY_UK=
-# STRIPE_WEBHOOK_SECRET_UK=
-# NEXT_PUBLIC_STRIPE_PORTAL_URL_UK=
+STRIPE_DEFAULT_REGION=us
+STRIPE_SECRET_KEY_US=
+NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY_US=
+STRIPE_WEBHOOK_SECRET_US=
+NEXT_PUBLIC_STRIPE_PORTAL_URL_US=
+STRIPE_SECRET_KEY_UK=
+NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY_UK=
+STRIPE_WEBHOOK_SECRET_UK=
+NEXT_PUBLIC_STRIPE_PORTAL_URL_UK=
 #
 # NEXT_PUBLIC_STRIPE_PORTAL_URL_* powers the public Footer / FAQ / About
 # "Manage Subscription" links and server-rendered email template links.
 # These URLs are not secrets, so use the same NEXT_PUBLIC values for both
-# browser and server surfaces. If you configure only one region during
-# rollout, the other region still renders the shared fallback URL rather
-# than dropping out.
+# browser and server surfaces.
 #
 # Webhook endpoints:
 #   /api/webhooks/stripe/{region}     preferred, validates against the

--- a/dotenv.sample
+++ b/dotenv.sample
@@ -7,6 +7,8 @@ NEXT_PUBLIC_MAPTILER_KEY=
 NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=
 STRIPE_SECRET_KEY=
 STRIPE_WEBHOOK_SECRET=
+# Legacy single-account server fallback for email portal links.
+# Prefer NEXT_PUBLIC_STRIPE_PORTAL_URL_US/UK for new deployments.
 STRIPE_PORTAL_URL=
 NEXT_PUBLIC_BASE_URL=https://localhost:3000/
 
@@ -27,19 +29,17 @@ NEXT_PUBLIC_BASE_URL=https://localhost:3000/
 # STRIPE_SECRET_KEY_US=
 # NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY_US=
 # STRIPE_WEBHOOK_SECRET_US=
-# STRIPE_PORTAL_URL_US=
 # NEXT_PUBLIC_STRIPE_PORTAL_URL_US=
 # STRIPE_SECRET_KEY_UK=
 # NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY_UK=
 # STRIPE_WEBHOOK_SECRET_UK=
-# STRIPE_PORTAL_URL_UK=
 # NEXT_PUBLIC_STRIPE_PORTAL_URL_UK=
 #
 # NEXT_PUBLIC_STRIPE_PORTAL_URL_* powers the public Footer / FAQ / About
-# "Manage Subscription" links. Server-side STRIPE_PORTAL_URL_* powers email
-# template links. Set both in production so the in-app link and the email
-# link agree. If you configure only one region during rollout, the other
-# region still renders a working link using the legacy
+# "Manage Subscription" links and server-rendered email template links.
+# These URLs are not secrets, so use the same NEXT_PUBLIC values for both
+# browser and server surfaces. If you configure only one region during
+# rollout, the other region still renders a working link using the legacy
 # https://stripe.creatorshare.com fallback rather than dropping out.
 #
 # Webhook endpoints:

--- a/src/app/api/paypal/route.ts
+++ b/src/app/api/paypal/route.ts
@@ -5,7 +5,6 @@ import {
   coerceSupportedCurrency,
   convertUsdCentsToCurrency,
   dollarsToCents,
-  centsToDollars,
   formatMoney,
   verifyCurrencyConversion,
 } from "@/utils/currency"

--- a/src/lib/stripe/config.ts
+++ b/src/lib/stripe/config.ts
@@ -16,15 +16,6 @@ export interface StripeRegionConfig {
   label: string
 }
 
-// Legacy unsuffixed vars are rollout fallbacks only. They configure the
-// STRIPE_DEFAULT_REGION account when region-specific values are absent.
-// Checkout account routing is selected-currency aware and lives in
-// getStripeRegionForPaymentCurrency().
-const LEGACY_SECRET_KEY = process.env.STRIPE_SECRET_KEY
-const LEGACY_PUBLISHABLE_KEY = process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY
-const LEGACY_WEBHOOK_SECRET = process.env.STRIPE_WEBHOOK_SECRET
-const LEGACY_PORTAL_URL = process.env.STRIPE_PORTAL_URL
-
 // Validate STRIPE_DEFAULT_REGION at module load: a typo like
 // STRIPE_DEFAULT_REGION=eu otherwise short-circuits coerceRegion() into
 // returning "eu", then crashes inside getStripeConfig with a confusing
@@ -48,38 +39,22 @@ export const STRIPE_DEFAULT_REGION: StripeRegion = isValidStripeRegion(
   ? RAW_DEFAULT_REGION_ENV
   : "us"
 
-// Region-specific env vars take precedence. Legacy unsuffixed vars are only
-// used for the default region during migration and never configure both
-// Stripe accounts.
+// Stripe accounts are configured explicitly per region. STRIPE_DEFAULT_REGION
+// only selects which configured account is used when a caller does not provide
+// a valid region.
 const REGION_ENV_MAP: Record<StripeRegion, StripeRegionConfig> = {
   us: {
-    secretKey:
-      process.env.STRIPE_SECRET_KEY_US ||
-      (STRIPE_DEFAULT_REGION === "us" ? LEGACY_SECRET_KEY || "" : ""),
-    publishableKey:
-      process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY_US ||
-      (STRIPE_DEFAULT_REGION === "us" ? LEGACY_PUBLISHABLE_KEY || "" : ""),
-    webhookSecret:
-      process.env.STRIPE_WEBHOOK_SECRET_US ||
-      (STRIPE_DEFAULT_REGION === "us" ? LEGACY_WEBHOOK_SECRET || "" : ""),
-    portalUrl:
-      process.env.NEXT_PUBLIC_STRIPE_PORTAL_URL_US ||
-      (STRIPE_DEFAULT_REGION === "us" ? LEGACY_PORTAL_URL || "" : ""),
+    secretKey: process.env.STRIPE_SECRET_KEY_US || "",
+    publishableKey: process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY_US || "",
+    webhookSecret: process.env.STRIPE_WEBHOOK_SECRET_US || "",
+    portalUrl: process.env.NEXT_PUBLIC_STRIPE_PORTAL_URL_US || "",
     label: "Creator Share US",
   },
   uk: {
-    secretKey:
-      process.env.STRIPE_SECRET_KEY_UK ||
-      (STRIPE_DEFAULT_REGION === "uk" ? LEGACY_SECRET_KEY || "" : ""),
-    publishableKey:
-      process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY_UK ||
-      (STRIPE_DEFAULT_REGION === "uk" ? LEGACY_PUBLISHABLE_KEY || "" : ""),
-    webhookSecret:
-      process.env.STRIPE_WEBHOOK_SECRET_UK ||
-      (STRIPE_DEFAULT_REGION === "uk" ? LEGACY_WEBHOOK_SECRET || "" : ""),
-    portalUrl:
-      process.env.NEXT_PUBLIC_STRIPE_PORTAL_URL_UK ||
-      (STRIPE_DEFAULT_REGION === "uk" ? LEGACY_PORTAL_URL || "" : ""),
+    secretKey: process.env.STRIPE_SECRET_KEY_UK || "",
+    publishableKey: process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY_UK || "",
+    webhookSecret: process.env.STRIPE_WEBHOOK_SECRET_UK || "",
+    portalUrl: process.env.NEXT_PUBLIC_STRIPE_PORTAL_URL_UK || "",
     label: "Creator Share UK",
   },
 }
@@ -112,7 +87,7 @@ export function getStripeConfig(
   const config = REGION_ENV_MAP[region]
   if (!config.secretKey) {
     throw new Error(
-      `Stripe region "${region}" is not configured — missing STRIPE_SECRET_KEY_${region.toUpperCase()}`,
+      `Stripe region "${region}" is not configured, missing STRIPE_SECRET_KEY_${region.toUpperCase()}`,
     )
   }
   return config

--- a/src/lib/stripe/config.ts
+++ b/src/lib/stripe/config.ts
@@ -13,10 +13,13 @@ export interface StripeRegionConfig {
   publishableKey: string
   webhookSecret: string
   portalUrl: string
-  currency: string
   label: string
 }
 
+// Legacy unsuffixed vars are rollout fallbacks only. They configure the
+// STRIPE_DEFAULT_REGION account when region-specific values are absent.
+// Checkout account routing is selected-currency aware and lives in
+// getStripeRegionForPaymentCurrency().
 const LEGACY_SECRET_KEY = process.env.STRIPE_SECRET_KEY
 const LEGACY_PUBLISHABLE_KEY = process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY
 const LEGACY_WEBHOOK_SECRET = process.env.STRIPE_WEBHOOK_SECRET
@@ -45,8 +48,9 @@ export const STRIPE_DEFAULT_REGION: StripeRegion = isValidStripeRegion(
   ? RAW_DEFAULT_REGION_ENV
   : "us"
 
-// Region-specific env vars take precedence; legacy unsuffixed vars act as
-// fallbacks for the primary region during migration.
+// Region-specific env vars take precedence. Legacy unsuffixed vars are only
+// used for the default region during migration and never configure both
+// Stripe accounts.
 const REGION_ENV_MAP: Record<StripeRegion, StripeRegionConfig> = {
   us: {
     secretKey:
@@ -61,7 +65,6 @@ const REGION_ENV_MAP: Record<StripeRegion, StripeRegionConfig> = {
     portalUrl:
       process.env.NEXT_PUBLIC_STRIPE_PORTAL_URL_US ||
       (STRIPE_DEFAULT_REGION === "us" ? LEGACY_PORTAL_URL || "" : ""),
-    currency: "usd",
     label: "Creator Share US",
   },
   uk: {
@@ -77,12 +80,6 @@ const REGION_ENV_MAP: Record<StripeRegion, StripeRegionConfig> = {
     portalUrl:
       process.env.NEXT_PUBLIC_STRIPE_PORTAL_URL_UK ||
       (STRIPE_DEFAULT_REGION === "uk" ? LEGACY_PORTAL_URL || "" : ""),
-    // TODO(uk-pricing): switch to "gbp" once the UI supports per-region
-    // currency display + a price table denominated in pence. Until then,
-    // bill UK Stripe in USD so the dollar amounts the UI shows match what
-    // the customer is charged. Otherwise a sponsor picking "$15/month"
-    // gets charged £15 (~$19), a ~25% silent overcharge.
-    currency: "usd",
     label: "Creator Share UK",
   },
 }

--- a/src/lib/stripe/config.ts
+++ b/src/lib/stripe/config.ts
@@ -59,7 +59,7 @@ const REGION_ENV_MAP: Record<StripeRegion, StripeRegionConfig> = {
       process.env.STRIPE_WEBHOOK_SECRET_US ||
       (STRIPE_DEFAULT_REGION === "us" ? LEGACY_WEBHOOK_SECRET || "" : ""),
     portalUrl:
-      process.env.STRIPE_PORTAL_URL_US ||
+      process.env.NEXT_PUBLIC_STRIPE_PORTAL_URL_US ||
       (STRIPE_DEFAULT_REGION === "us" ? LEGACY_PORTAL_URL || "" : ""),
     currency: "usd",
     label: "Creator Share US",
@@ -75,7 +75,7 @@ const REGION_ENV_MAP: Record<StripeRegion, StripeRegionConfig> = {
       process.env.STRIPE_WEBHOOK_SECRET_UK ||
       (STRIPE_DEFAULT_REGION === "uk" ? LEGACY_WEBHOOK_SECRET || "" : ""),
     portalUrl:
-      process.env.STRIPE_PORTAL_URL_UK ||
+      process.env.NEXT_PUBLIC_STRIPE_PORTAL_URL_UK ||
       (STRIPE_DEFAULT_REGION === "uk" ? LEGACY_PORTAL_URL || "" : ""),
     // TODO(uk-pricing): switch to "gbp" once the UI supports per-region
     // currency display + a price table denominated in pence. Until then,


### PR DESCRIPTION
(AI Generated).

## Summary

Fixes the failed Vercel deployment from the merge of PR #108 and cleans up Stripe account configuration.

## Changes

- Removes the unused `centsToDollars` import from `src/app/api/paypal/route.ts`, which was blocking `next build` during lint validation.
- Removes duplicate region-specific server portal env vars from `dotenv.sample`.
- Reuses `NEXT_PUBLIC_STRIPE_PORTAL_URL_US` and `NEXT_PUBLIC_STRIPE_PORTAL_URL_UK` for both browser links and server-rendered email links, since portal URLs are not secrets.
- Removes the unused `StripeRegionConfig.currency` field and the stale UK-in-USD comment from Stripe config.
- Removes legacy unsuffixed Stripe env fallbacks from `src/lib/stripe/config.ts` and `dotenv.sample`. Account config now comes from explicit region-specific env vars only.

## Stripe routing

Sponsor checkout routing is selected-currency aware, not location aware:

- `USD` routes to the US Stripe account.
- `AUD`, `GBP`, and `EUR` route to the UK Stripe account.

Location detection still helps preselect the user-facing currency dropdown. It should not choose the Stripe account directly, because a user can manually override currency. The selected currency is the authoritative routing input.

## Environment instructions

For production, configure:

```text
STRIPE_DEFAULT_REGION=us
STRIPE_SECRET_KEY_US=
NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY_US=
STRIPE_WEBHOOK_SECRET_US=
NEXT_PUBLIC_STRIPE_PORTAL_URL_US=
STRIPE_SECRET_KEY_UK=
NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY_UK=
STRIPE_WEBHOOK_SECRET_UK=
NEXT_PUBLIC_STRIPE_PORTAL_URL_UK=
```

Do not rely on unsuffixed legacy Stripe vars for this multi-account flow. `STRIPE_DEFAULT_REGION` is only the fallback region selector when a caller does not provide a valid region. It does not provide fallback credentials.

## Root cause

The merged `dev` branch failed during `next build` with:

```text
./src/app/api/paypal/route.ts
8:3 Error: 'centsToDollars' is defined but never used. @typescript-eslint/no-unused-vars
```

The portal URL duplication was not the build failure, but it created unnecessary deployment configuration surface. Secret Stripe values remain server-only. Portal URLs now use the public region env vars everywhere.

## Validation

- `git diff --check`
- `yarn build`
- `npx --yes vercel@latest build`
