### PR TITLE
Add Vercel Analytics to dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@chakra-ui/react": "^3.27.0",
     "@emotion/react": "^11.14.0",
+    "@vercel/analytics": "^2.0.1",
     "@paypal/checkout-server-sdk": "^1.0.3",
     "@paypal/react-paypal-js": "^8.8.3",
     "@stripe/react-stripe-js": "^3.5.1",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import { Providers } from "@/components/Providers"
 import "@/styles/globals.css"
 import { PageWrapper } from "@/components/PageWrapper"
 import { Toaster } from "@/components/ui/toaster"
+import { Analytics } from "@vercel/analytics/next"
 
 const redditSans = Reddit_Sans({
   subsets: ["latin"],
@@ -34,6 +35,7 @@ export default function RootLayout({
           </main>
           <Toaster />
         </Providers>
+        <Analytics />
       </body>
     </html>
   )

--- a/yarn.lock
+++ b/yarn.lock
@@ -1357,6 +1357,11 @@
   resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.11.1.tgz#538b1e103bf8d9864e7b85cc96fa8d6fb6c40777"
   integrity sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==
 
+"@vercel/analytics@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@vercel/analytics/-/analytics-2.0.1.tgz#d7d7bd37af7cfbeea95db5f132ae4889f4d26407"
+  integrity sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==
+
 "@zag-js/accordion@1.39.1":
   version "1.39.1"
   resolved "https://registry.yarnpkg.com/@zag-js/accordion/-/accordion-1.39.1.tgz#e91f07f772111d6487591ee6408de7eb5eeac681"


### PR DESCRIPTION
(AI Generated).

## Summary

Brings the Vercel Web Analytics integration from PR #112 into `dev`.

PR #112 was merged into `main`, so this cherry-picks the same analytics change onto current `dev`.

## Changes

- Adds `@vercel/analytics` to dependencies.
- Adds `<Analytics />` to `src/app/layout.tsx` using the Next.js App Router integration.
- Updates `yarn.lock` for the new dependency.

## Validation

- `git diff --check`
- `yarn install --frozen-lockfile`
- `yarn build`
- `npx --yes vercel@latest build`
