### PR TITLE
Deduplicate public portal links

### DIFF
--- a/src/lib/payments/portals.ts
+++ b/src/lib/payments/portals.ts
@@ -1,13 +1,7 @@
-// Self-service portal links for Stripe (per-region) and PayPal. Reads only
+// Self-service portal links for Stripe and PayPal. Reads only
 // NEXT_PUBLIC_* env vars and the lightweight region type module, so it is
 // safe to import from client components (Footer, FAQ, About) as well as
 // server-side email rendering.
-//
-// Fallback semantics (per-region, not all-or-nothing): any region that is
-// not configured via NEXT_PUBLIC_STRIPE_PORTAL_URL_<REGION> falls back to
-// DEFAULT_STRIPE_PORTAL_URL. This means a deployment that configures only
-// UK during rollout still renders a working US "Manage Subscription" link
-// pointed at the legacy hosted portal.
 
 import {
   ALL_STRIPE_REGIONS,
@@ -20,12 +14,6 @@ export const PAYPAL_MANAGE_URL = "https://www.paypal.com/myaccount/autopay/"
 export interface PortalLink {
   provider: "STRIPE" | "PAYPAL"
   region?: StripeRegion
-  // True when the href is the shared DEFAULT_STRIPE_PORTAL_URL rather than a
-  // region-specific NEXT_PUBLIC_STRIPE_PORTAL_URL_<REGION>. UI can use this to
-  // collapse duplicates or annotate the link (e.g. "Manage Subscription (UK,
-  // legacy)") so users aren't surprised when two region links point at the
-  // same portal during a partial rollout.
-  isFallback?: boolean
   href: string
   label: string
 }
@@ -43,43 +31,58 @@ const PUBLIC_PORTAL_URLS: Record<StripeRegion, string | undefined> = {
   uk: process.env.NEXT_PUBLIC_STRIPE_PORTAL_URL_UK,
 }
 
-export function getPublicPortalLinks(): PortalLink[] {
-  const links: PortalLink[] = []
+export function buildStripePortalLinks(
+  portalUrls: Record<StripeRegion, string | undefined>,
+): PortalLink[] {
+  const linksByHref = new Map<string, StripeRegion[]>()
 
-  // If NO region-specific URLs are configured at all, render the legacy
-  // single "Manage Subscription" link (no region label) to keep single-
-  // account deployments looking unchanged.
-  const anyRegionConfigured = ALL_STRIPE_REGIONS.some(
-    (region) => !!PUBLIC_PORTAL_URLS[region],
-  )
+  for (const region of ALL_STRIPE_REGIONS) {
+    const href = portalUrls[region]?.trim()
+    if (!href) continue
 
-  if (!anyRegionConfigured) {
-    links.push({
-      provider: "STRIPE",
-      href: DEFAULT_STRIPE_PORTAL_URL,
-      label: "Manage Subscription",
-    })
-  } else {
-    // At least one region is configured. Render a link for every region,
-    // falling back to the legacy URL for any region without a NEXT_PUBLIC_
-    // override so partial-rollout deployments don't drop the other regions.
-    // Fallback links carry isFallback=true so the UI can dedupe or annotate
-    // them (two regions both pointing at the legacy portal would otherwise
-    // be indistinguishable in the footer).
-    for (const region of ALL_STRIPE_REGIONS) {
-      const override = PUBLIC_PORTAL_URLS[region]
-      const isFallback = !override
-      links.push({
-        provider: "STRIPE",
-        region,
-        isFallback,
-        href: override || DEFAULT_STRIPE_PORTAL_URL,
-        label: isFallback
-          ? `Manage Subscription (${STRIPE_REGION_LABELS[region]}, legacy)`
-          : `Manage Subscription (${STRIPE_REGION_LABELS[region]})`,
-      })
-    }
+    const regions = linksByHref.get(href) || []
+    regions.push(region)
+    linksByHref.set(href, regions)
   }
+
+  if (linksByHref.size === 0) {
+    return [
+      {
+        provider: "STRIPE",
+        href: DEFAULT_STRIPE_PORTAL_URL,
+        label: "Manage Subscription",
+      },
+    ]
+  }
+
+  if (linksByHref.size === 1) {
+    const [href] = linksByHref.keys()
+    return [
+      {
+        provider: "STRIPE",
+        href,
+        label: "Manage Subscription",
+      },
+    ]
+  }
+
+  return Array.from(linksByHref.entries()).map(([href, regions]) => {
+    const [primaryRegion] = regions
+    const label = regions
+      .map((region) => STRIPE_REGION_LABELS[region])
+      .join(", ")
+
+    return {
+      provider: "STRIPE",
+      region: primaryRegion,
+      href,
+      label: `Manage Subscription (${label})`,
+    }
+  })
+}
+
+export function getPublicPortalLinks(): PortalLink[] {
+  const links = buildStripePortalLinks(PUBLIC_PORTAL_URLS)
 
   if (process.env.NEXT_PUBLIC_PAYPAL_CLIENT_ID) {
     links.push({

--- a/tests/portals.spec.ts
+++ b/tests/portals.spec.ts
@@ -1,0 +1,55 @@
+import { expect, test } from "@playwright/test"
+
+import {
+  buildStripePortalLinks,
+  DEFAULT_STRIPE_PORTAL_URL,
+} from "../src/lib/payments/portals"
+
+test.describe("public portal links", () => {
+  test("uses one generic Stripe link when no region portal URLs are configured", () => {
+    expect(buildStripePortalLinks({ us: undefined, uk: undefined })).toEqual([
+      {
+        provider: "STRIPE",
+        href: DEFAULT_STRIPE_PORTAL_URL,
+        label: "Manage Subscription",
+      },
+    ])
+  })
+
+  test("dedupes region portal URLs that point to the same destination", () => {
+    expect(
+      buildStripePortalLinks({
+        us: "https://stripe.example.com/portal",
+        uk: "https://stripe.example.com/portal",
+      }),
+    ).toEqual([
+      {
+        provider: "STRIPE",
+        href: "https://stripe.example.com/portal",
+        label: "Manage Subscription",
+      },
+    ])
+  })
+
+  test("labels Stripe portal links by region only when destinations differ", () => {
+    expect(
+      buildStripePortalLinks({
+        us: "https://stripe.example.com/us",
+        uk: "https://stripe.example.com/uk",
+      }),
+    ).toEqual([
+      {
+        provider: "STRIPE",
+        region: "us",
+        href: "https://stripe.example.com/us",
+        label: "Manage Subscription (US)",
+      },
+      {
+        provider: "STRIPE",
+        region: "uk",
+        href: "https://stripe.example.com/uk",
+        label: "Manage Subscription (UK)",
+      },
+    ])
+  })
+})


### PR DESCRIPTION
(AI Generated).

## Summary

Fixes public Stripe portal links so US and UK entries do not render as separate links when they point to the same destination.

## Changes

- Adds `buildStripePortalLinks()` to normalize Stripe portal links before Footer, FAQ, and About render them.
- Renders one generic `Manage Subscription` link when no region portal URLs are configured.
- Renders one generic `Manage Subscription` link when US and UK portal URLs are the same.
- Renders region-specific `Manage Subscription (US)` and `Manage Subscription (UK)` links only when the configured destinations differ.
- Removes the old partial rollout fallback behavior that produced duplicate-looking links.
- Adds Playwright coverage for no config, duplicate URLs, and distinct region URLs.

## Validation

- `git diff --check`
- `PW_NO_WEBSERVER=1 npx playwright test tests/portals.spec.ts`
- `yarn build`
- `npx --yes vercel@latest build`
