### PR TITLE
Fix public filter reset status

### DIFF
--- a/src/app/sponsorships/components/SponsorshipFilters/index.tsx
+++ b/src/app/sponsorships/components/SponsorshipFilters/index.tsx
@@ -180,8 +180,8 @@ const SponsorshipFilters: React.FC<
     e.preventDefault()
 
     const defaultStatus = isAdminMode
-      ? ["New", "Partially Funded", "Budget Fulfilled", "Draft", "Archived", "Sponsorship Cancelled"]
-      : ["New", "Partially Funded", "Sponsorship Cancelled"]
+      ? [...ALL_STATUSES]
+      : [...PUBLIC_STATUSES]
 
     isInternalUpdateRef.current = true
 


### PR DESCRIPTION
(AI Generated).

## Summary
* Reset public filters with PUBLIC_STATUSES instead of a hardcoded narrower status list.
* Reset admin filters with ALL_STATUSES for the same source of truth.

## Root cause
The public clear action omitted Budget Fulfilled, while the dirty check used PUBLIC_STATUSES. That left status filtered after show all and displayed 1 active filter.

## Validation
* npm run lint
* npx tsc --noEmit
