### PR TITLE
Fix Stripe webhook region persistence

### DIFF
--- a/src/app/api/webhooks/stripe/handler.ts
+++ b/src/app/api/webhooks/stripe/handler.ts
@@ -5,6 +5,7 @@ import {
   getWebhookSecret,
   type StripeRegion,
 } from "@/lib/stripe/config"
+import { getStripeRegionForPaymentMetadata } from "@/lib/stripe/currencyRouting"
 import { createServiceRoleClient } from "@/utils/supabase/server"
 import {
   type CurrencyConversion,
@@ -91,13 +92,14 @@ function validateStripeCurrencyAmount(
 }
 
 export async function handleStripeWebhook(req: Request, region: StripeRegion) {
-  const stripe = getStripeClient(region)
+  const requestRegion = region
+  const stripe = getStripeClient(requestRegion)
   const supabase = createServiceRoleClient()
   const sig = req.headers.get("stripe-signature") as string
 
   let webhookSecret: string
   try {
-    webhookSecret = getWebhookSecret(region)
+    webhookSecret = getWebhookSecret(requestRegion)
   } catch (err) {
     console.error("Webhook secret lookup failed:", err)
     return NextResponse.json(
@@ -125,6 +127,19 @@ export async function handleStripeWebhook(req: Request, region: StripeRegion) {
   }
 
   try {
+    const eventRegion = getStripeRegionForPaymentMetadata(
+      (event.data.object as { metadata?: Stripe.Metadata | null }).metadata,
+      requestRegion,
+    )
+    if (eventRegion !== requestRegion) {
+      console.error("Stripe webhook route region differs from payment metadata:", {
+        eventId: event.id,
+        eventType: event.type,
+        requestRegion,
+        eventRegion,
+      })
+    }
+    const region = eventRegion
 
     switch (event.type) {
       case "checkout.session.completed": {

--- a/src/components/FAQModal.tsx
+++ b/src/components/FAQModal.tsx
@@ -161,8 +161,17 @@ export const FAQModal: React.FC<FAQModalProps> = ({ open, onClose, prevPath }) =
                         rel="noopener noreferrer"
                         className="inline-flex flex-1 min-w-[200px] items-center justify-between gap-3 px-5 py-3.5 bg-white border border-gray-200 rounded-xl text-sm hover:border-[#2b7ff9] hover:shadow-sm hover:text-[#2b7ff9] transition-all group"
                       >
-                        <span className="font-semibold text-gray-800 group-hover:text-[#2b7ff9] transition-colors">
-                          {link.region === "us" ? "🇺🇸 USD" : link.region === "uk" ? "🇬🇧 GBP / EUR / AUD" : "Manage Subscription"}
+                        <span className="flex flex-col gap-1">
+                          <span className="font-semibold text-gray-800 group-hover:text-[#2b7ff9] transition-colors">
+                            {link.region === "us"
+                              ? "🇺🇸 USD"
+                              : link.region === "uk"
+                                ? "🇬🇧 GBP / EUR / AUD"
+                                : "Manage Subscription"}
+                          </span>
+                          <span className="text-xs font-medium text-gray-500 group-hover:text-[#2b7ff9] transition-colors">
+                            Manage subscription here
+                          </span>
                         </span>
                         <FaExternalLinkAlt className="w-3 h-3 text-gray-400 group-hover:text-[#2b7ff9] flex-shrink-0 transition-colors" />
                       </a>

--- a/src/lib/stripe/currencyRouting.ts
+++ b/src/lib/stripe/currencyRouting.ts
@@ -1,8 +1,18 @@
-import type { StripeRegion } from "@/lib/stripe/region"
+import {
+  isValidStripeRegion,
+  type StripeRegion,
+} from "@/lib/stripe/region"
 import { coerceSupportedCurrency } from "@/utils/currency"
 
 export function getStripeRegionForPaymentCurrency(
   currency: string | null | undefined,
 ): StripeRegion {
   return coerceSupportedCurrency(currency) === "USD" ? "us" : "uk"
+}
+
+export function getStripeRegionForPaymentMetadata(
+  metadata: Record<string, string | null | undefined> | null | undefined,
+  fallback: StripeRegion,
+): StripeRegion {
+  return isValidStripeRegion(metadata?.region) ? metadata.region : fallback
 }

--- a/tests/currency.spec.ts
+++ b/tests/currency.spec.ts
@@ -5,7 +5,10 @@ import {
   formatMoney,
   getDefaultCurrencyForCountry,
 } from "../src/utils/currency"
-import { getStripeRegionForPaymentCurrency } from "../src/lib/stripe/currencyRouting"
+import {
+  getStripeRegionForPaymentCurrency,
+  getStripeRegionForPaymentMetadata,
+} from "../src/lib/stripe/currencyRouting"
 
 test.describe("payment currency support", () => {
   test("maps supported countries to the expected default currencies", () => {
@@ -65,6 +68,19 @@ test.describe("payment currency support", () => {
     expect(getStripeRegionForPaymentCurrency("AUD")).toBe("uk")
     expect(getStripeRegionForPaymentCurrency("GBP")).toBe("uk")
     expect(getStripeRegionForPaymentCurrency("EUR")).toBe("uk")
+  })
+
+  test("prefers checkout metadata region over legacy webhook route fallback", () => {
+    expect(getStripeRegionForPaymentMetadata({ region: "uk" }, "us")).toBe(
+      "uk",
+    )
+    expect(getStripeRegionForPaymentMetadata({ region: "us" }, "uk")).toBe(
+      "us",
+    )
+    expect(getStripeRegionForPaymentMetadata({ region: "nope" }, "us")).toBe(
+      "us",
+    )
+    expect(getStripeRegionForPaymentMetadata(null, "uk")).toBe("uk")
   })
 
   test("currency detection endpoint reads the Vercel country header", async ({


### PR DESCRIPTION
(AI Generated). 

## Summary

Fixes Stripe webhook region persistence when a non USD checkout reaches the legacy webhook route. The handler now verifies the signature using the route region, then persists and notifies with the checkout metadata region when it is present.

Also includes the local FAQ modal update that adds a short helper line under each manage subscription portal link.

## Root Cause

The Stripe dashboard endpoint was still pointed at `/api/webhooks/stripe`, which delegates to the default `us` region. Recent GBP and EUR checkout sessions carried `region: uk` metadata, but the webhook handler stored `payment_region = us` because it trusted the legacy route fallback.

## Validation

- `npx playwright test tests/currency.spec.ts`
- `npx tsc --noEmit`
- `git diff --check`

## Follow Up

The Stripe webhook endpoint should still be moved from `/api/webhooks/stripe` to the region specific URL, for example `/api/webhooks/stripe/uk`, so future events enter through the intended route.
