### PR TITLE
Add beneficiary type to sponsorship Telegram notifications

### DIFF
--- a/src/app/api/paypal/webhook/route.ts
+++ b/src/app/api/paypal/webhook/route.ts
@@ -180,7 +180,7 @@ export async function POST(req: Request) {
           const { data: beneficiary, error: beneficiaryError } = beneficiaryId
             ? await supabase
                 .from("beneficiaries")
-                .select("name")
+                .select("name, beneficiary_type")
                 .eq("id", beneficiaryId)
                 .single()
             : { data: null, error: null }
@@ -229,6 +229,7 @@ export async function POST(req: Request) {
               chargedCurrency: conversion.chargedCurrency,
               beneficiaryId,
               beneficiaryName,
+              beneficiaryType: beneficiary?.beneficiary_type || null,
               paymentMethod: "PayPal",
               paymentReference: orderId,
               interval: "one_time",
@@ -295,7 +296,7 @@ export async function POST(req: Request) {
         const { data: beneficiary, error: beneficiaryError } = beneficiaryId
           ? await supabase
               .from("beneficiaries")
-              .select("name")
+              .select("name, beneficiary_type")
               .eq("id", beneficiaryId)
               .single()
           : { data: null, error: null }
@@ -378,6 +379,7 @@ export async function POST(req: Request) {
               chargedCurrency: conversion.chargedCurrency,
               beneficiaryId: beneficiaryId,
               beneficiaryName: beneficiaryName,
+              beneficiaryType: beneficiary?.beneficiary_type || null,
               paymentMethod: "PayPal",
               paymentReference: recurringReference,
             })
@@ -419,7 +421,7 @@ export async function POST(req: Request) {
         const { data: beneficiary, error: beneficiaryError } = beneficiaryId
           ? await supabase
               .from("beneficiaries")
-              .select("name")
+              .select("name, beneficiary_type")
               .eq("id", beneficiaryId)
               .single()
           : { data: null, error: null }
@@ -549,6 +551,7 @@ export async function POST(req: Request) {
               chargedCurrency: conversion?.chargedCurrency,
               beneficiaryId: beneficiaryId,
               beneficiaryName: beneficiaryName,
+              beneficiaryType: beneficiary?.beneficiary_type || null,
               paymentMethod: "PayPal",
               paymentReference: paypalSubscriptionId,
             })

--- a/src/app/api/stripe/route.ts
+++ b/src/app/api/stripe/route.ts
@@ -72,6 +72,7 @@ export async function POST(req: Request) {
       userId,
       isEmbedded,
       type,
+      beneficiaryType,
       project,
       email,
       sponsorshipMode,
@@ -178,6 +179,7 @@ export async function POST(req: Request) {
             sponsorshipMode: resolvedSponsorshipMode,
             blindLabel: resolvedBlindLabel,
             beneficiaryName: resolvedBeneficiaryName,
+            beneficiaryType: beneficiaryType || null,
             ...paymentCurrencyMetadata,
           }
 
@@ -217,6 +219,7 @@ export async function POST(req: Request) {
             paymentType,
             sponsorshipMode: resolvedSponsorshipMode,
             blindLabel: resolvedBlindLabel,
+            beneficiaryType: beneficiaryType || null,
             region,
             creatorshare_platform: "true",
             ...paymentCurrencyMetadata,
@@ -263,6 +266,7 @@ export async function POST(req: Request) {
                   sponsorshipMode: resolvedSponsorshipMode,
                   blindLabel: resolvedBlindLabel,
                   beneficiaryName: resolvedBeneficiaryName,
+                  beneficiaryType: beneficiaryType || undefined,
                   region,
                   creatorshare_platform: "true",
                   ...paymentCurrencyMetadata,

--- a/src/app/api/webhooks/stripe/handler.ts
+++ b/src/app/api/webhooks/stripe/handler.ts
@@ -417,6 +417,7 @@ export async function handleStripeWebhook(req: Request) {
         const isBlindSponsorship = sponsorshipMode === "blind"
         const beneficiaryId = session.metadata?.beneficiaryId || null
         const beneficiaryNameFromMetadata = session.metadata?.beneficiaryName
+        let beneficiaryType = session.metadata?.beneficiaryType || null
         const blindLabel =
           session.metadata?.blindLabel || "the next child who needs support"
         const userId = session.metadata?.userId || null
@@ -647,7 +648,7 @@ export async function handleStripeWebhook(req: Request) {
           const { data: beneficiaryData, error: beneficiaryError } =
             await supabase
               .from("beneficiaries")
-              .select("name")
+              .select("name, beneficiary_type")
               .eq("id", beneficiaryId)
               .single()
 
@@ -656,6 +657,7 @@ export async function handleStripeWebhook(req: Request) {
             // Continue processing - this is not critical
           } else if (beneficiaryData?.name) {
             beneficiaryName = beneficiaryData.name
+            beneficiaryType = beneficiaryData.beneficiary_type || beneficiaryType
           }
         }
 
@@ -805,6 +807,7 @@ export async function handleStripeWebhook(req: Request) {
             chargedCurrency: conversion.chargedCurrency,
             beneficiaryId: beneficiaryId,
             beneficiaryName: beneficiaryName,
+            beneficiaryType,
             paymentMethod: providerLabel(sessionProvider),
             paymentReference: session.id,
             interval: interval,

--- a/src/app/sponsorships/components/SponsorshipModal/index.tsx
+++ b/src/app/sponsorships/components/SponsorshipModal/index.tsx
@@ -428,6 +428,7 @@ const BeneficiaryModal: React.FC<BeneficiaryModalProps> = ({
       const payload = {
         beneficiaryId: beneficiary.id,
         beneficiaryName: beneficiary.name,
+        beneficiaryType: beneficiary.beneficiary_type,
         amount: isOpen ? amountCents : beneficiary.budget_goal,
         paymentType,
         location: beneficiary.country,

--- a/src/config/beneficiaryTypes.ts
+++ b/src/config/beneficiaryTypes.ts
@@ -200,6 +200,20 @@ export function isFixedSponsorshipType(
   return Boolean(config?.type && !config.isOpenSponsorship)
 }
 
+export function getBeneficiaryTypeLabel(
+  type: BeneficiaryTabType | string | null | undefined,
+): string | null {
+  if (!type) return null
+  const config = findConfig(type)
+  if (config?.label) return config.label
+
+  return type
+    .split("_")
+    .filter(Boolean)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+    .join(" ")
+}
+
 export function hasOpenSponsorshipSupport(beneficiary: {
   active_subscriptions?: number | null
   budget_raised?: number | null

--- a/src/services/telegram.ts
+++ b/src/services/telegram.ts
@@ -16,6 +16,7 @@ import {
   MediaRow,
 } from "@/utils/supabase/media"
 import { createServiceRoleClient } from "@/utils/supabase/server"
+import { getBeneficiaryTypeLabel } from "@/config/beneficiaryTypes"
 
 // Single Responsibility Principle (SRP) - Telegram service only handles Telegram operations
 export class TelegramBotService implements TelegramNotificationService {
@@ -275,7 +276,8 @@ export class TelegramBotService implements TelegramNotificationService {
       interval,
       sponsorName,
       sponsorEmail,
-      paymentMethod
+      paymentMethod,
+      beneficiaryType,
     } = sponsorshipData;
 
     const amountFormatted = chargedCurrency
@@ -283,11 +285,13 @@ export class TelegramBotService implements TelegramNotificationService {
       : `$${(amount / 100).toFixed(2)}`;
     const intervalText = interval === 'month' ? 'Monthly' : interval === 'one_time' ? 'One-time' : 'Yearly';
     const sponsorDisplayName = sponsorName || sponsorEmail?.split('@')[0] || 'Anonymous';
+    const beneficiaryTypeLabel = getBeneficiaryTypeLabel(beneficiaryType) || 'Not specified';
 
     return `
 🎉 <b>New Sponsorship Received!</b>
 
 👤 <b>Beneficiary:</b> ${beneficiaryName}
+🏷️ <b>Beneficiary Type:</b> ${beneficiaryTypeLabel}
 💰 <b>Amount:</b> ${amountFormatted}
 🔄 <b>Type:</b> ${intervalText}${interval === 'month' || interval === 'year' ? ' Recurring' : ''}
 💳 <b>Payment Method:</b> ${paymentMethod}

--- a/src/types/telegram.types.ts
+++ b/src/types/telegram.types.ts
@@ -25,6 +25,7 @@ export interface SponsorshipNotificationData {
   chargedCurrency?: string;
   beneficiaryId?: string | null;
   beneficiaryName: string;
+  beneficiaryType?: string | null;
   paymentMethod: string;
   paymentReference: string;
   interval?: string;


### PR DESCRIPTION
(AI Generated).

## Summary
- Adds beneficiary type support to sponsorship notification payloads.
- Displays a Beneficiary Type line in Telegram using configured labels.
- Passes type metadata from checkout and fetches it in Stripe and PayPal webhook paths.

## Validation
- npm run build
- npx tsc --noEmit